### PR TITLE
fix: remove trailing empty lines from targets file

### DIFF
--- a/tools/tikwm/cmd/helpers.go
+++ b/tools/tikwm/cmd/helpers.go
@@ -185,6 +185,10 @@ func manageTargetsFile(targetLine, targetType, filePath string, console *cli.Con
 		console.Info("Moving processed user to the end of targets file.")
 		userLine := lines[targetIdx]
 		tempLines := append(lines[:targetIdx], lines[targetIdx+1:]...)
+		// Remove all trailing empty lines from tempLines
+		for len(tempLines) > 0 && strings.TrimSpace(tempLines[len(tempLines)-1]) == "" {
+			tempLines = tempLines[:len(tempLines)-1]
+		}
 		newLines = append(tempLines, userLine)
 	}
 


### PR DESCRIPTION
Removed all trailing empty lines before re-appending the processed user to the end of the targets file

Ran the CLI tool with multiple users in the targets file

Verified that no extra blank lines appear between entries or at the end of the file