### PR TITLE
refactor(lib): make sqlite implementation extensible and decouple core config from CLI

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,25 +1,8 @@
 package config
 
-import (
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/adrg/xdg"
-	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/file"
-	"github.com/knadh/koanf/v2"
-)
-
-const AppName = "tikwm" // Define the application name.
-
-// Config struct holds the application configuration.
+// Config struct holds the core, application-agnostic configuration.
 type Config struct {
 	DownloadPath    string `koanf:"download_path"`    // Path to download videos and images.
-	TargetsFile     string `koanf:"targets_file"`     // Path to the targets file.
-	DatabasePath    string `koanf:"database_path"`    // Path to the SQLite database.
 	Quality         string `koanf:"quality"`          // Quality of the downloaded videos ("source", "hd", "sd", "all").
 	Since           string `koanf:"since"`            // Date to download content since (YYYY-MM-DD HH:MM:SS).
 	RetryOn429      bool   `koanf:"retry_on_429"`     // Retry download on 429 error.
@@ -28,133 +11,19 @@ type Config struct {
 	DownloadAvatars bool   `koanf:"download_avatars"` // Download user profile avatars.
 	SavePostTitle   bool   `koanf:"save_post_title"`  // Save the post title to a .txt file.
 	FfmpegPath      string `koanf:"ffmpeg_path"`      // Path to the ffmpeg executable.
-	Editor          string `koanf:"editor"`           // Editor to use for editing.
 }
 
-// Default returns the default configuration.
-func Default() (*Config, error) {
-	dbPath, err := xdg.DataFile(filepath.Join(AppName, "history.db")) // Get the default database path.
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default db path: %w", err) // Return error if failed.
+// Default returns the default core configuration.
+func Default() *Config {
+	return &Config{
+		DownloadPath:    "./downloads",
+		Quality:         "source",
+		Since:           "1970-01-01 00:00:00",
+		RetryOn429:      false,
+		DownloadCovers:  false,
+		CoverType:       "cover",
+		DownloadAvatars: false,
+		SavePostTitle:   false,
+		FfmpegPath:      "ffmpeg",
 	}
-	targetsPath, err := xdg.DataFile(filepath.Join(AppName, "targets.txt")) // Get the default targets file path.
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default targets path: %w", err) // Return error if failed.
-	}
-	return &Config{ // Return the default configuration.
-		DownloadPath:    "./downloads",         // Default download path.
-		TargetsFile:     targetsPath,           // Default targets file path.
-		DatabasePath:    dbPath,                // Default database path.
-		Quality:         "source",              // Default quality.
-		Since:           "1970-01-01 00:00:00", // Default since date.
-		RetryOn429:      false,                 // Default retry on 429.
-		DownloadCovers:  false,                 // Default download covers.
-		CoverType:       "cover",               // Default cover type.
-		DownloadAvatars: false,                 // Default download avatars.
-		SavePostTitle:   false,                 // Default save post title.
-		FfmpegPath:      "ffmpeg",              // Default ffmpeg path.
-		Editor:          "",                    // Default editor.
-	}, nil
-}
-
-// Load loads the configuration from the given path.
-func Load(path string) (*Config, error) {
-	k := koanf.New(".")      // Create a new Koanf instance.
-	defCfg, err := Default() // Get the default configuration.
-	if err != nil {
-		return nil, err // Return error if failed.
-	}
-	cfgPath := path    // Set the config path.
-	if cfgPath == "" { // If the config path is empty.
-		cfgPath, err = xdg.ConfigFile(filepath.Join(AppName, "config.yaml")) // Get the default config path.
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default config path: %w", err) // Return error if failed.
-		}
-	}
-	if _, err := os.Stat(cfgPath); errors.Is(err, os.ErrNotExist) { // If the config file does not exist.
-		if err := createDefaultConfig(cfgPath, defCfg); err != nil { // Create the default config file.
-			return nil, fmt.Errorf("failed to create default config: %w", err) // Return error if failed.
-		}
-	}
-	if err := k.Load(file.Provider(cfgPath), yaml.Parser()); err != nil { // Load the config file.
-		return nil, fmt.Errorf("failed to load config file: %w", err) // Return error if failed.
-	}
-	cfg := defCfg                                // Set the config to the default config.
-	if err := k.Unmarshal("", cfg); err != nil { // Unmarshal the config.
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err) // Return error if failed.
-	}
-
-	// If the user's config specifies an empty string for targets_file,
-	// fall back to the new default path to avoid errors.
-	if cfg.TargetsFile == "" {
-		cfg.TargetsFile = defCfg.TargetsFile
-	}
-
-	if _, err := os.Stat(cfg.TargetsFile); errors.Is(err, os.ErrNotExist) { // If the targets file does not exist.
-		if err := createDefaultTargetsFile(cfg.TargetsFile); err != nil { // Create the default targets file.
-			// Not a fatal error, just warn the user.
-			fmt.Fprintf(os.Stderr, "Warning: failed to create default targets file: %v\n", err) // Print a warning message.
-		}
-	}
-	return cfg, nil // Return the config.
-}
-
-// createDefaultConfig creates a default configuration file.
-func createDefaultConfig(path string, cfg *Config) error {
-	dir := filepath.Dir(path)                      // Get the directory of the config file.
-	if err := os.MkdirAll(dir, 0750); err != nil { // Create the directory if it does not exist.
-		return fmt.Errorf("failed to create config directory: %w", err) // Return error if failed.
-	}
-	content := fmt.Sprintf(`# tikwm CLI configuration file.
-# Path where videos and images will be downloaded.
-download_path: "%s"
-# Path to a file containing a list of targets (usernames or URLs), one per line.
-# This file is used if no targets are provided on the command line.
-targets_file: "%s"
-# Path to the SQLite database to track downloaded posts.
-database_path: "%s"
-# Quality to download videos in. Options: "source", "hd", "sd", "all".
-quality: "%s"
-# Default date to download content since (YYYY-MM-DD HH:MM:SS).
-since: "%s"
-# Set to true to download video cover images along with the video.
-download_covers: %t
-# Type of cover to download. Options:
-# "cover" or "medium": The standard, medium-quality cover.
-# "origin" or "small": A slightly smaller, lower-qualtiy cover.
-# "dynamic": An animated dynamic cover.
-cover_type: "%s"
-# Set to true to download user profile avatars.
-download_avatars: %t
-# Set to true to save the post title to a .txt file.
-save_post_title: %t
-# When rate-limited (429) on an HD link, retry with backoff or fall back to SD?
-# Set to true to retry with backoff, false to fall back to SD.
-retry_on_429: %t
-# Path to the ffmpeg executable. Used to validate downloaded videos.
-ffmpeg_path: "%s"
-# Editor to use for the 'edit' command. If empty, it will check $EDITOR, then common editors.
-editor: "%s"
-`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.Editor) // Format the config file content.
-	content = strings.ReplaceAll(content, "\\", "/")                  // Replace backslashes with forward slashes.
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil { // Write the config file.
-		return fmt.Errorf("failed to write default config file: %w", err) // Return error if failed.
-	}
-	return nil // Return nil if successful.
-}
-
-// createDefaultTargetsFile creates a default targets file.
-func createDefaultTargetsFile(path string) error {
-	dir := filepath.Dir(path)                      // Get the directory of the targets file.
-	if err := os.MkdirAll(dir, 0750); err != nil { // Create the directory if it does not exist.
-		return fmt.Errorf("failed to create targets directory: %w", err) // Return error if failed.
-	}
-	content := `# Add TikTok usernames or video URLs here, one per line.
-# Lines starting with # are ignored.
-#
-# Example:
-# losertron
-# https://www.tiktok.com/@creator/video/12345
-` // Default targets file content.
-	return os.WriteFile(path, []byte(content), 0600) // Write the targets file.
 }

--- a/pkg/storage/sqlite/queries/add_avatar.sql
+++ b/pkg/storage/sqlite/queries/add_avatar.sql
@@ -1,0 +1,1 @@
+INSERT OR IGNORE INTO avatars (author_id, sha256, downloaded_at) VALUES (?, ?, ?);

--- a/pkg/storage/sqlite/queries/asset_exists.sql.tpl
+++ b/pkg/storage/sqlite/queries/asset_exists.sql.tpl
@@ -1,0 +1,1 @@
+SELECT {{.Column}} FROM posts WHERE id = ?;

--- a/pkg/storage/sqlite/queries/avatar_exists.sql
+++ b/pkg/storage/sqlite/queries/avatar_exists.sql
@@ -1,0 +1,1 @@
+SELECT EXISTS(SELECT 1 FROM avatars WHERE author_id = ? AND sha256 = ?);

--- a/pkg/storage/sqlite/queries/count_album_photos.sql
+++ b/pkg/storage/sqlite/queries/count_album_photos.sql
@@ -1,0 +1,1 @@
+SELECT count(*) FROM posts WHERE id LIKE ?;

--- a/pkg/storage/sqlite/queries/delete_post.sql
+++ b/pkg/storage/sqlite/queries/delete_post.sql
@@ -1,0 +1,1 @@
+DELETE FROM posts WHERE id = ?;

--- a/pkg/storage/sqlite/queries/get_missing_posts_by_author.sql.tpl
+++ b/pkg/storage/sqlite/queries/get_missing_posts_by_author.sql.tpl
@@ -1,0 +1,4 @@
+SELECT id, author_id, create_time, (has_cover_medium OR has_cover_origin OR has_cover_dynamic) as has_cover
+FROM posts
+WHERE author_id = ? AND {{.HasColumn}} = 0 AND id NOT LIKE '%_%'
+ORDER BY create_time DESC;

--- a/pkg/storage/sqlite/queries/get_posts_by_author.sql
+++ b/pkg/storage/sqlite/queries/get_posts_by_author.sql
@@ -1,0 +1,4 @@
+SELECT id, author_id, create_time, (has_cover_medium OR has_cover_origin OR has_cover_dynamic) as has_cover
+FROM posts
+WHERE author_id = ?
+ORDER BY create_time DESC;

--- a/pkg/storage/sqlite/queries/schema.sql
+++ b/pkg/storage/sqlite/queries/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS posts (
+    id TEXT PRIMARY KEY,
+    author_id TEXT NOT NULL,
+    create_time INTEGER NOT NULL,
+    has_sd BOOLEAN NOT NULL DEFAULT 0,
+    has_hd BOOLEAN NOT NULL DEFAULT 0,
+    has_source BOOLEAN NOT NULL DEFAULT 0,
+    has_cover_medium BOOLEAN NOT NULL DEFAULT 0,
+    has_cover_origin BOOLEAN NOT NULL DEFAULT 0,
+    has_cover_dynamic BOOLEAN NOT NULL DEFAULT 0,
+    sha256_sd TEXT,
+    sha256_hd TEXT,
+    sha256_source TEXT,
+    sha256_cover_medium TEXT,
+    sha256_cover_origin TEXT,
+    sha256_cover_dynamic TEXT,
+    downloaded_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_author_id_create_time ON posts (author_id, create_time);
+
+CREATE TABLE IF NOT EXISTS avatars (
+    author_id TEXT NOT NULL,
+    sha256 TEXT NOT NULL,
+    downloaded_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (author_id, sha256)
+);

--- a/pkg/storage/sqlite/queries/upsert_asset.sql.tpl
+++ b/pkg/storage/sqlite/queries/upsert_asset.sql.tpl
@@ -1,0 +1,6 @@
+INSERT INTO posts (id, author_id, create_time, {{.HasColumn}}, {{.ShaColumn}}, downloaded_at)
+VALUES (?, ?, ?, 1, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    {{.HasColumn}} = 1,
+    {{.ShaColumn}} = excluded.{{.ShaColumn}},
+    downloaded_at = excluded.downloaded_at;

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -1,11 +1,14 @@
 package sqlite
 
 import (
+	"bytes"
 	"database/sql"
+	"embed"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"text/template"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -13,74 +16,80 @@ import (
 	"github.com/perpetuallyhorni/tikwm/pkg/storage"
 )
 
+//go:embed queries/*.sql
+//go:embed queries/*.sql.tpl
+var queryFS embed.FS
+
 // DB is a SQLite implementation of the storage.Storer interface.
 type DB struct {
-	*sql.DB // Embed the standard sql.DB type.
+	Conn *sql.DB // The raw database connection, exposed for extensibility.
 }
 
 // New creates a new SQLite database connection and ensures the schema is up to date.
-func New(path string) (storage.Storer, error) {
-	// Determine the directory for the database file.
+// It returns a concrete *DB type to allow for extension.
+func New(path string) (*DB, error) {
 	dir := filepath.Dir(path)
-	// Create the directory if it doesn't exist.
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)
 	}
-	// Use WAL mode for better concurrency, but manage it carefully.
+
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s?_journal_mode=WAL", path))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
-	// Ensure the connection is valid by pinging the database.
+
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
-	// Create the database schema if it doesn't exist.
-	if err := createSchema(db); err != nil {
+
+	instance := &DB{Conn: db}
+	if err := instance.createSchema(); err != nil {
+		_ = instance.Close()
 		return nil, fmt.Errorf("failed to create database schema: %w", err)
 	}
-	// Return a new DB instance wrapping the sql.DB connection.
-	return &DB{db}, nil
+
+	return instance, nil
+}
+
+// getQuery reads a raw SQL query from the embedded filesystem.
+func getQuery(name string) (string, error) {
+	b, err := queryFS.ReadFile("queries/" + name)
+	if err != nil {
+		return "", fmt.Errorf("failed to read embedded query %s: %w", name, err)
+	}
+	return string(b), nil
+}
+
+// getParsedQuery parses and executes a SQL template from the embedded filesystem.
+func getParsedQuery(templateName string, data any) (string, error) {
+	t, err := template.ParseFS(queryFS, "queries/"+templateName)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse embedded query template %s: %w", templateName, err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute embedded query template %s: %w", templateName, err)
+	}
+	return buf.String(), nil
 }
 
 // createSchema creates the necessary tables in the SQLite database if they don't exist.
-func createSchema(db *sql.DB) error {
-	query := `
-	CREATE TABLE IF NOT EXISTS posts (
-		id TEXT PRIMARY KEY,
-		author_id TEXT NOT NULL,
-		create_time INTEGER NOT NULL,
-		has_sd BOOLEAN NOT NULL DEFAULT 0,
-		has_hd BOOLEAN NOT NULL DEFAULT 0,
-		has_source BOOLEAN NOT NULL DEFAULT 0,
-		has_cover_medium BOOLEAN NOT NULL DEFAULT 0,
-		has_cover_origin BOOLEAN NOT NULL DEFAULT 0,
-		has_cover_dynamic BOOLEAN NOT NULL DEFAULT 0,
-		sha256_sd TEXT,
-		sha256_hd TEXT,
-		sha256_source TEXT,
-		sha256_cover_medium TEXT,
-		sha256_cover_origin TEXT,
-		sha256_cover_dynamic TEXT,
-		downloaded_at TIMESTAMP
-	);
-	CREATE INDEX IF NOT EXISTS idx_author_id_create_time ON posts (author_id, create_time);
-	
-	CREATE TABLE IF NOT EXISTS avatars (
-		author_id TEXT NOT NULL,
-		sha256 TEXT NOT NULL,
-		downloaded_at TIMESTAMP NOT NULL,
-		PRIMARY KEY (author_id, sha256)
-	);
-	`
-	_, err := db.Exec(query)
+func (db *DB) createSchema() error {
+	query, err := getQuery("schema.sql")
+	if err != nil {
+		return err
+	}
+	_, err = db.Conn.Exec(query)
 	return err
 }
 
 // AddAvatar adds a record for a downloaded user avatar.
 func (db *DB) AddAvatar(authorID, sha256 string) error {
-	query := `INSERT OR IGNORE INTO avatars (author_id, sha256, downloaded_at) VALUES (?, ?, ?)`
-	_, err := db.Exec(query, authorID, sha256, time.Now())
+	query, err := getQuery("add_avatar.sql")
+	if err != nil {
+		return err
+	}
+	_, err = db.Conn.Exec(query, authorID, sha256, time.Now())
 	if err != nil {
 		return fmt.Errorf("failed to insert avatar for author %s: %w", authorID, err)
 	}
@@ -89,9 +98,12 @@ func (db *DB) AddAvatar(authorID, sha256 string) error {
 
 // AvatarExists checks if a specific avatar hash for an author is already in the database.
 func (db *DB) AvatarExists(authorID, sha256 string) (bool, error) {
+	query, err := getQuery("avatar_exists.sql")
+	if err != nil {
+		return false, err
+	}
 	var exists bool
-	query := `SELECT EXISTS(SELECT 1 FROM avatars WHERE author_id = ? AND sha256 = ?)`
-	err := db.QueryRow(query, authorID, sha256).Scan(&exists)
+	err = db.Conn.QueryRow(query, authorID, sha256).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if avatar exists for author %s: %w", authorID, err)
 	}
@@ -101,7 +113,6 @@ func (db *DB) AvatarExists(authorID, sha256 string) (bool, error) {
 // AddOrUpdateAsset uses an atomic "upsert" for a generic asset and forces a WAL checkpoint.
 func (db *DB) AddOrUpdateAsset(postID, authorID string, createTime int64, assetType tikwm.AssetType, sha256 string) error {
 	var hasColumn, shaColumn string
-	// Determine the column names based on the asset type.
 	switch assetType {
 	case tikwm.AssetSD:
 		hasColumn, shaColumn = "has_sd", "sha256_sd"
@@ -116,40 +127,37 @@ func (db *DB) AddOrUpdateAsset(postID, authorID string, createTime int64, assetT
 	case tikwm.AssetCoverDynamic:
 		hasColumn, shaColumn = "has_cover_dynamic", "sha256_cover_dynamic"
 	case tikwm.AssetAlbumPhoto:
-		// Album photos are simple, they just use the HD columns for presence.
 		hasColumn, shaColumn = "has_hd", "sha256_hd"
 	default:
 		return fmt.Errorf("unknown asset type for DB operation: %s", assetType)
 	}
 
-	// Construct the SQL query for inserting or updating the asset.
-	query := fmt.Sprintf(`
-		INSERT INTO posts (id, author_id, create_time, %[1]s, %[2]s, downloaded_at)
-		VALUES (?, ?, ?, 1, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
-			%[1]s = 1,
-			%[2]s = excluded.%[2]s,
-			downloaded_at = excluded.downloaded_at;
-	`, hasColumn, shaColumn)
+	query, err := getParsedQuery("upsert_asset.sql.tpl", struct {
+		HasColumn string
+		ShaColumn string
+	}{
+		HasColumn: hasColumn,
+		ShaColumn: shaColumn,
+	})
+	if err != nil {
+		return err
+	}
 
-	_, err := db.Exec(query, postID, authorID, createTime, sha256, time.Now())
+	_, err = db.Conn.Exec(query, postID, authorID, createTime, sha256, time.Now())
 	if err != nil {
 		return fmt.Errorf("failed to execute upsert for post %s (type: %s): %w", postID, assetType, err)
 	}
 
-	// Force a WAL checkpoint to ensure data is written to disk.
-	_, err = db.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
+	_, err = db.Conn.Exec("PRAGMA wal_checkpoint(TRUNCATE);")
 	if err != nil {
 		return fmt.Errorf("failed to checkpoint WAL after upsert for post %s: %w", postID, err)
 	}
-
 	return nil
 }
 
 // AssetExists checks if a specific asset for a post exists in the database.
 func (db *DB) AssetExists(assetID string, assetType tikwm.AssetType) (bool, error) {
 	var column string
-	// Determine the column name based on the asset type.
 	switch assetType {
 	case tikwm.AssetSD:
 		column = "has_sd"
@@ -164,14 +172,17 @@ func (db *DB) AssetExists(assetID string, assetType tikwm.AssetType) (bool, erro
 	case tikwm.AssetCoverDynamic:
 		column = "has_cover_dynamic"
 	case tikwm.AssetAlbumPhoto:
-		column = "has_hd" // piggy-backing on hd for simple existence check
+		column = "has_hd"
 	default:
 		return false, fmt.Errorf("unknown asset type for existence check: %s", assetType)
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM posts WHERE id = ?", column)
+	query, err := getParsedQuery("asset_exists.sql.tpl", struct{ Column string }{Column: column})
+	if err != nil {
+		return false, err
+	}
 	var exists bool
-	err := db.QueryRow(query, assetID).Scan(&exists)
+	err = db.Conn.QueryRow(query, assetID).Scan(&exists)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -183,13 +194,14 @@ func (db *DB) AssetExists(assetID string, assetType tikwm.AssetType) (bool, erro
 
 // GetAlbumPhotoCount retrieves the number of downloaded photos for an album.
 func (db *DB) GetAlbumPhotoCount(postID string) (int, error) {
-	query := `SELECT count(*) FROM posts WHERE id LIKE ?`
-	// The post ID is numeric, so an underscore is a safe separator.
+	query, err := getQuery("count_album_photos.sql")
+	if err != nil {
+		return 0, err
+	}
 	pattern := postID + `_%`
 	var count int
-	err := db.QueryRow(query, pattern).Scan(&count)
+	err = db.Conn.QueryRow(query, pattern).Scan(&count)
 	if err != nil {
-		// count(*) doesn't return sql.ErrNoRows, just 0. So any error is a real problem.
 		return 0, fmt.Errorf("failed to count album photos for %s: %w", postID, err)
 	}
 	return count, nil
@@ -197,8 +209,11 @@ func (db *DB) GetAlbumPhotoCount(postID string) (int, error) {
 
 // DeletePost deletes a post record by its exact ID.
 func (db *DB) DeletePost(postID string) error {
-	query := `DELETE FROM posts WHERE id = ?`
-	_, err := db.Exec(query, postID)
+	query, err := getQuery("delete_post.sql")
+	if err != nil {
+		return err
+	}
+	_, err = db.Conn.Exec(query, postID)
 	if err != nil {
 		return fmt.Errorf("failed to delete post %s: %w", postID, err)
 	}
@@ -207,12 +222,14 @@ func (db *DB) DeletePost(postID string) error {
 
 // GetPostsByAuthor retrieves all post records for a given author from the database.
 func (db *DB) GetPostsByAuthor(authorID string) ([]storage.PostRecord, error) {
-	query := `SELECT id, author_id, create_time, has_cover FROM posts WHERE author_id = ? ORDER BY create_time DESC`
-	rows, err := db.Query(query, authorID)
+	query, err := getQuery("get_posts_by_author.sql")
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.Conn.Query(query, authorID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query posts for author %s: %w", authorID, err)
 	}
-	// Ensure rows are closed after function completes.
 	defer func() {
 		if err := rows.Close(); err != nil {
 			fmt.Printf("failed to close rows: %v", err)
@@ -220,46 +237,38 @@ func (db *DB) GetPostsByAuthor(authorID string) ([]storage.PostRecord, error) {
 	}()
 
 	var posts []storage.PostRecord
-	// Iterate through the rows returned by the query.
 	for rows.Next() {
 		var p storage.PostRecord
-		// Scan the values from the row into the PostRecord struct.
 		if err := rows.Scan(&p.ID, &p.AuthorID, &p.CreateTime, &p.HasCover); err != nil {
 			return nil, fmt.Errorf("failed to scan post row: %w", err)
 		}
-		// Append the PostRecord to the slice of posts.
 		posts = append(posts, p)
 	}
-
-	// Check for errors during row iteration.
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error during row iteration for author %s: %w", authorID, err)
 	}
-
 	return posts, nil
 }
 
-// GetMissingPostsByAuthor retrieves all post records for a given author from the database
-// that are missing a specific asset type (hd or sd).
+// GetMissingPostsByAuthor retrieves post records that are missing a specific asset type.
 func (db *DB) GetMissingPostsByAuthor(authorID string, assetType tikwm.AssetType) ([]storage.PostRecord, error) {
-	var query string
-	// Exclude album photos from fix command by checking for underscores in the ID,
-	// since base post IDs are numeric and do not contain them.
-	const albumExclusion = `AND id NOT LIKE '%_%'`
+	var hasColumn string
 	switch assetType {
 	case tikwm.AssetHD:
-		query = `SELECT id, author_id, create_time, has_cover FROM posts WHERE author_id = ? AND has_hd = 0 ` + albumExclusion + ` ORDER BY create_time DESC`
+		hasColumn = "has_hd"
 	case tikwm.AssetSD:
-		query = `SELECT id, author_id, create_time, has_cover FROM posts WHERE author_id = ? AND has_sd = 0 ` + albumExclusion + ` ORDER BY create_time DESC`
+		hasColumn = "has_sd"
 	default:
 		return nil, fmt.Errorf("unsupported asset type for fix: %s", assetType)
 	}
-
-	rows, err := db.Query(query, authorID)
+	query, err := getParsedQuery("get_missing_posts_by_author.sql.tpl", struct{ HasColumn string }{HasColumn: hasColumn})
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.Conn.Query(query, authorID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query missing posts for author %s: %w", authorID, err)
 	}
-	// Ensure rows are closed after function completes.
 	defer func() {
 		if err := rows.Close(); err != nil {
 			fmt.Printf("failed to close rows: %v", err)
@@ -267,26 +276,20 @@ func (db *DB) GetMissingPostsByAuthor(authorID string, assetType tikwm.AssetType
 	}()
 
 	var posts []storage.PostRecord
-	// Iterate through the rows returned by the query.
 	for rows.Next() {
 		var p storage.PostRecord
-		// Scan the values from the row into the PostRecord struct.
 		if err := rows.Scan(&p.ID, &p.AuthorID, &p.CreateTime, &p.HasCover); err != nil {
 			return nil, fmt.Errorf("failed to scan post row: %w", err)
 		}
-		// Append the PostRecord to the slice of posts.
 		posts = append(posts, p)
 	}
-
-	// Check for errors during row iteration.
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error during row iteration for author %s: %w", authorID, err)
 	}
-
 	return posts, nil
 }
 
 // Close closes the database connection.
 func (db *DB) Close() error {
-	return db.DB.Close()
+	return db.Conn.Close()
 }

--- a/tools/tikwm/cmd/download.go
+++ b/tools/tikwm/cmd/download.go
@@ -31,7 +31,7 @@ func runDownload(cmd *cobra.Command, args []string) error {
 	for _, targetStr := range targets {
 		parsed := parseTarget(targetStr) // Parse the target string.
 		// Process the target.
-		err := processTarget(parsed, appClient, fileLogger, console, cfg, force)
+		err := processTarget(parsed, appClient, fileLogger, console, force)
 		if err != nil {
 			console.Error("Error processing target '%s': %v", targetStr, err) // Log an error if processing fails.
 		} else {

--- a/tools/tikwm/cmd/edit.go
+++ b/tools/tikwm/cmd/edit.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"github.com/adrg/xdg"
-	"github.com/perpetuallyhorni/tikwm/pkg/config"
+	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +31,7 @@ var editConfigCmd = &cobra.Command{
 		configFilePath, _ := cmd.Flags().GetString("config")
 		if configFilePath == "" {
 			var findErr error
-			configFilePath, findErr = xdg.ConfigFile(filepath.Join(config.AppName, "config.yaml"))
+			configFilePath, findErr = xdg.ConfigFile(filepath.Join(cliconfig.AppName, "config.yaml"))
 			if findErr != nil {
 				return fmt.Errorf("could not determine default config file path: %w", findErr)
 			}

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -7,16 +7,16 @@ import (
 	"os"
 
 	"github.com/perpetuallyhorni/tikwm/pkg/client"
-	"github.com/perpetuallyhorni/tikwm/pkg/config"
 	"github.com/perpetuallyhorni/tikwm/pkg/storage"
 	"github.com/perpetuallyhorni/tikwm/pkg/storage/sqlite"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
+	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var (
 	// cfg stores the application configuration.
-	cfg *config.Config
+	cfg *cliconfig.Config
 	// appClient is the client used to interact with the TikTok API.
 	appClient *client.Client
 	// console is the CLI console for output.
@@ -78,8 +78,8 @@ For example:
 			return fmt.Errorf("error initializing database: %w", err)
 		}
 
-		// Create a new client.
-		appClient, err = client.New(cfg, database)
+		// Create a new client, passing the embedded core config.
+		appClient, err = client.New(&cfg.Config, database)
 		if err != nil {
 			return fmt.Errorf("error creating client: %w", err)
 		}
@@ -120,7 +120,7 @@ func init() {
 		}
 
 		// Load the config file.
-		cfg, err = config.Load(flagConfigPath)
+		cfg, err = cliconfig.Load(flagConfigPath)
 		if err != nil {
 			console.Error("Error loading config: %v", err)
 			os.Exit(1)

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/perpetuallyhorni/tikwm/pkg/client"
-	"github.com/perpetuallyhorni/tikwm/pkg/storage"
 	"github.com/perpetuallyhorni/tikwm/pkg/storage/sqlite"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
 	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
@@ -24,7 +23,7 @@ var (
 	// fileLogger is the logger for writing logs to a file.
 	fileLogger *log.Logger
 	// database is the storage interface for storing data.
-	database storage.Storer
+	database *sqlite.DB
 	// flagConfigPath is the path to the config file.
 	flagConfigPath string
 	// flagQuiet enables or disables quiet mode.
@@ -78,7 +77,7 @@ For example:
 			return fmt.Errorf("error initializing database: %w", err)
 		}
 
-		// Create a new client, passing the embedded core config.
+		// Create a new client, passing the database which satisfies the storage.Storer interface.
 		appClient, err = client.New(&cfg.Config, database)
 		if err != nil {
 			return fmt.Errorf("error creating client: %w", err)

--- a/tools/tikwm/internal/config/config.go
+++ b/tools/tikwm/internal/config/config.go
@@ -1,0 +1,147 @@
+package cliconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/adrg/xdg"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
+	"github.com/perpetuallyhorni/tikwm/pkg/config"
+)
+
+const AppName = "tikwm"
+
+// Config extends the core config with CLI-specific options.
+type Config struct {
+	config.Config `koanf:",squash"`
+	TargetsFile   string `koanf:"targets_file"`
+	DatabasePath  string `koanf:"database_path"`
+	Editor        string `koanf:"editor"`
+}
+
+// Default returns the default CLI configuration.
+func Default() (*Config, error) {
+	coreCfg := config.Default()
+	dbPath, err := xdg.DataFile(filepath.Join(AppName, "history.db"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default db path: %w", err)
+	}
+	targetsPath, err := xdg.DataFile(filepath.Join(AppName, "targets.txt"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default targets path: %w", err)
+	}
+
+	return &Config{
+		Config:       *coreCfg,
+		DatabasePath: dbPath,
+		TargetsFile:  targetsPath,
+		Editor:       "", // Default editor is determined in the 'edit' command logic
+	}, nil
+}
+
+// Load loads the configuration from the given path.
+func Load(path string) (*Config, error) {
+	k := koanf.New(".")
+	defCfg, err := Default()
+	if err != nil {
+		return nil, err
+	}
+	cfgPath := path
+	if cfgPath == "" {
+		cfgPath, err = xdg.ConfigFile(filepath.Join(AppName, "config.yaml"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default config path: %w", err)
+		}
+	}
+	if _, err := os.Stat(cfgPath); errors.Is(err, os.ErrNotExist) {
+		if err := createDefaultConfig(cfgPath, defCfg); err != nil {
+			return nil, fmt.Errorf("failed to create default config: %w", err)
+		}
+	}
+	if err := k.Load(file.Provider(cfgPath), yaml.Parser()); err != nil {
+		return nil, fmt.Errorf("failed to load config file: %w", err)
+	}
+	cfg := defCfg
+	if err := k.Unmarshal("", cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// If the user's config specifies an empty string for targets_file,
+	// fall back to the new default path to avoid errors.
+	if cfg.TargetsFile == "" {
+		cfg.TargetsFile = defCfg.TargetsFile
+	}
+
+	if _, err := os.Stat(cfg.TargetsFile); errors.Is(err, os.ErrNotExist) {
+		if err := createDefaultTargetsFile(cfg.TargetsFile); err != nil {
+			// Not a fatal error, just warn the user.
+			fmt.Fprintf(os.Stderr, "Warning: failed to create default targets file: %v\n", err)
+		}
+	}
+	return cfg, nil
+}
+
+// createDefaultConfig creates a default configuration file.
+func createDefaultConfig(path string, cfg *Config) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	content := fmt.Sprintf(`# tikwm CLI configuration file.
+# Path where videos and images will be downloaded.
+download_path: "%s"
+# Path to a file containing a list of targets (usernames or URLs), one per line.
+# This file is used if no targets are provided on the command line.
+targets_file: "%s"
+# Path to the SQLite database to track downloaded posts.
+database_path: "%s"
+# Quality to download videos in. Options: "source", "hd", "sd", "all".
+quality: "%s"
+# Default date to download content since (YYYY-MM-DD HH:MM:SS).
+since: "%s"
+# Set to true to download video cover images along with the video.
+download_covers: %t
+# Type of cover to download. Options:
+# "cover" or "medium": The standard, medium-quality cover.
+# "origin" or "small": A slightly smaller, lower-qualtiy cover.
+# "dynamic": An animated dynamic cover.
+cover_type: "%s"
+# Set to true to download user profile avatars.
+download_avatars: %t
+# Set to true to save the post title to a .txt file.
+save_post_title: %t
+# When rate-limited (429) on an HD link, retry with backoff or fall back to SD?
+# Set to true to retry with backoff, false to fall back to SD.
+retry_on_429: %t
+# Path to the ffmpeg executable. Used to validate downloaded videos.
+ffmpeg_path: "%s"
+# Editor to use for the 'edit' command. If empty, it will check $EDITOR, then common editors.
+editor: "%s"
+`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.Editor)
+	content = strings.ReplaceAll(content, "\\", "/")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write default config file: %w", err)
+	}
+	return nil
+}
+
+// createDefaultTargetsFile creates a default targets file.
+func createDefaultTargetsFile(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create targets directory: %w", err)
+	}
+	content := `# Add TikTok usernames or video URLs here, one per line.
+# Lines starting with # are ignored.
+#
+# Example:
+# losertron
+# https://www.tiktok.com/@creator/video/12345
+`
+	return os.WriteFile(path, []byte(content), 0600)
+}


### PR DESCRIPTION
Refactor the sqlite storage backend to provide and extensible implementation for library consumers.

Move all SQL statements out of Go code and into their own `.sql` and `.sql.tpl` files in `pkg/storage/sqlite/queries`.
Use `//go:embed` to embed these query files into the binary at compile time.
Use `text/template` to handle dynamic query generation safely.
Change `sqlite.New` to return a concrete `*sqlite.DB` type instead of the `storage.Storer` interface.
Expose the raw `*sql.DB` connection via a public `Conn` field on the `sqlite.DB` struct.
Allow consumers to receive a fully initialized database connection that they can extend with their own tables and queries, while still using the core functionality provided by the Storer interface.
Fix a latent bug where GetPostsByAuthor was querying a non-existent 'has_cover' column.

Separate the core library configuration from the CLI-specific implementation.

Create `tools/tikwm/internal/config` (`cliconfig` package) to house all CLI-specific configuration logic, including file loading, default path generation (XDG), and management of CLI-specific settings like `targets_file` and `editor`.
Embed the core `pkg/config.Config` struct using the `cliconfig.Config` struct, extending it for CLI use.
Refactor `pkg/config` to be a lean, reusable library component. It now only defines the core configuration struct and its defaults, with no knowledge of the CLI, file I/O, or specific paths.
Update the client and command layers to work with this new structure. The CLI now passes the core config component (`&cfg.Config`) to the client.

Closes #12 