### PR TITLE
feat: implement self-update mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/fatih/color v1.18.0
+	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.0
 	github.com/knadh/koanf/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
+github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+)
+
 // Config struct holds the core, application-agnostic configuration.
 type Config struct {
 	DownloadPath    string `koanf:"download_path"`    // Path to download videos and images.
@@ -15,8 +21,17 @@ type Config struct {
 
 // Default returns the default core configuration.
 func Default() *Config {
+	var defaultPath string
+	downloadDir := xdg.UserDirs.Download
+	if downloadDir != "" {
+		defaultPath = filepath.Join(downloadDir, "tikwm")
+	} else {
+		// Fallback for systems without a configured XDG downloads directory.
+		defaultPath = filepath.Join("downloads", "tikwm")
+	}
+
 	return &Config{
-		DownloadPath:    "./downloads",
+		DownloadPath:    defaultPath,
 		Quality:         "source",
 		Since:           "1970-01-01 00:00:00",
 		RetryOn429:      false,

--- a/tools/tikwm/cmd/update.go
+++ b/tools/tikwm/cmd/update.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/update"
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command.
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update tikwm to the latest version.",
+	Long: `Checks for the latest version of tikwm on GitHub and, if a newer version is found,
+downloads and installs it.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// ApplyUpdate now contains all necessary logic, including checking if already latest.
+		return update.ApplyUpdate(console, version)
+	},
+}

--- a/tools/tikwm/internal/config/config.go
+++ b/tools/tikwm/internal/config/config.go
@@ -18,10 +18,12 @@ const AppName = "tikwm"
 
 // Config extends the core config with CLI-specific options.
 type Config struct {
-	config.Config `koanf:",squash"`
-	TargetsFile   string `koanf:"targets_file"`
-	DatabasePath  string `koanf:"database_path"`
-	Editor        string `koanf:"editor"`
+	config.Config   `koanf:",squash"`
+	TargetsFile     string `koanf:"targets_file"`
+	DatabasePath    string `koanf:"database_path"`
+	Editor          string `koanf:"editor"`
+	CheckForUpdates bool   `koanf:"check_for_updates"` // Check for new versions on startup.
+	AutoUpdate      bool   `koanf:"auto_update"`       // Automatically install new versions.
 }
 
 // Default returns the default CLI configuration.
@@ -37,10 +39,12 @@ func Default() (*Config, error) {
 	}
 
 	return &Config{
-		Config:       *coreCfg,
-		DatabasePath: dbPath,
-		TargetsFile:  targetsPath,
-		Editor:       "", // Default editor is determined in the 'edit' command logic
+		Config:          *coreCfg,
+		DatabasePath:    dbPath,
+		TargetsFile:     targetsPath,
+		Editor:          "", // Default editor is determined in the 'edit' command logic
+		CheckForUpdates: true,
+		AutoUpdate:      false,
 	}, nil
 }
 
@@ -122,7 +126,11 @@ retry_on_429: %t
 ffmpeg_path: "%s"
 # Editor to use for the 'edit' command. If empty, it will check $EDITOR, then common editors.
 editor: "%s"
-`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.Editor)
+# Check for new versions of tikwm on startup.
+check_for_updates: %t
+# Automatically install new versions of tikwm. If false, you will be notified to run 'tikwm update'.
+auto_update: %t
+`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
 	content = strings.ReplaceAll(content, "\\", "/")
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write default config file: %w", err)
@@ -141,6 +149,7 @@ func createDefaultTargetsFile(path string) error {
 #
 # Example:
 # losertron
+# @tiktok
 # https://www.tiktok.com/@creator/video/12345
 `
 	return os.WriteFile(path, []byte(content), 0600)

--- a/tools/tikwm/internal/update/update.go
+++ b/tools/tikwm/internal/update/update.go
@@ -1,0 +1,288 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/inconshreveable/go-update"
+	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
+)
+
+const (
+	repoOwner        = "perpetuallyhorni"
+	repoName         = "tikwm"
+	latestReleaseURL = "https://api.github.com/repos/perpetuallyhorni/tikwm/releases/latest"
+)
+
+// githubRelease represents the structure of a GitHub release API response.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name        string `json:"name"`
+		DownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// version represents a parsed version string.
+type version struct {
+	Major int
+	Minor int
+}
+
+// parseVersion parses a string like "v1.01" into a version struct.
+func parseVersion(vStr string) (version, error) {
+	vStr = strings.TrimPrefix(vStr, "v")
+	parts := strings.Split(vStr, ".")
+	if len(parts) != 2 {
+		return version{}, fmt.Errorf("invalid version format: %s", vStr)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return version{}, fmt.Errorf("invalid major version: %w", err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return version{}, fmt.Errorf("invalid minor version: %w", err)
+	}
+	return version{Major: major, Minor: minor}, nil
+}
+
+// lessThan compares two versions.
+func (v version) lessThan(other version) bool {
+	if v.Major < other.Major {
+		return true
+	}
+	if v.Major == other.Major && v.Minor < other.Minor {
+		return true
+	}
+	return false
+}
+
+// getLatestRelease fetches the latest release information from GitHub.
+func getLatestRelease() (*githubRelease, error) {
+	req, err := http.NewRequest(http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch latest release info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status from GitHub API: %s", resp.Status)
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode release info: %w", err)
+	}
+	return &release, nil
+}
+
+// CheckForUpdate checks for a new version on GitHub.
+// It returns the latest version tag if an update is available, otherwise an empty string.
+func CheckForUpdate(currentVersion string) (string, error) {
+	if currentVersion == "dev" {
+		return "", nil
+	}
+	release, err := getLatestRelease()
+	if err != nil {
+		return "", err
+	}
+
+	current, err := parseVersion(currentVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse current version: %w", err)
+	}
+	latest, err := parseVersion(release.TagName)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse latest version tag: %w", err)
+	}
+
+	if current.lessThan(latest) {
+		return release.TagName, nil
+	}
+
+	return "", nil
+}
+
+// getArchName maps Go's runtime.GOARCH to the goreleaser archive name format.
+func getArchName() string {
+	arch := runtime.GOARCH
+	if arch == "amd64" {
+		return "x86_64"
+	}
+	return arch
+}
+
+// getAssetName constructs the expected asset filename.
+func getAssetName() string {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	return fmt.Sprintf("%s_%s_%s.%s", repoName, runtime.GOOS, getArchName(), ext)
+}
+
+// extractFileFromArchive extracts the binary from the downloaded archive.
+func extractFileFromArchive(body io.Reader, filename string) (io.Reader, error) {
+	var binData []byte
+	var binFound bool
+
+	archiveBody, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read archive body: %w", err)
+	}
+
+	binaryName := "tikwm"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+
+	if strings.HasSuffix(filename, ".zip") {
+		r, err := zip.NewReader(bytes.NewReader(archiveBody), int64(len(archiveBody)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create zip reader: %w", err)
+		}
+		for _, f := range r.File {
+			if !f.FileInfo().IsDir() && filepath.Base(f.Name) == binaryName {
+				rc, err := f.Open()
+				if err != nil {
+					return nil, fmt.Errorf("failed to open file in zip: %w", err)
+				}
+				binData, err = io.ReadAll(rc)
+				defer func() {
+					if err := rc.Close(); err != nil {
+						fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
+					}
+				}()
+				if err != nil {
+					return nil, fmt.Errorf("failed to read executable from zip: %w", err)
+				}
+				binFound = true
+				break
+			}
+		}
+	} else { // .tar.gz
+		gzr, err := gzip.NewReader(bytes.NewReader(archiveBody))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzr.Close()
+		tr := tar.NewReader(gzr)
+		for {
+			header, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("tar reading error: %w", err)
+			}
+			if header.Typeflag == tar.TypeReg && filepath.Base(header.Name) == binaryName {
+				binData, err = io.ReadAll(tr)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read executable from tarball: %w", err)
+				}
+				binFound = true
+				break
+			}
+		}
+	}
+
+	if !binFound {
+		return nil, fmt.Errorf("executable '%s' not found in archive", binaryName)
+	}
+	return bytes.NewReader(binData), nil
+}
+
+// ApplyUpdate performs the self-update to the latest version.
+func ApplyUpdate(console *cli.Console, currentVersion string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not locate executable path: %w", err)
+	}
+	if strings.Contains(exe, "go-build") {
+		console.Error("Update command cannot be used with `go run`.")
+		console.Info("Please build or install the binary first, then run the update on the compiled executable.")
+		return nil
+	}
+
+	if currentVersion == "dev" {
+		console.Warn("Cannot update 'dev' version.")
+		return nil
+	}
+	console.Info("Checking for latest version...")
+	release, err := getLatestRelease()
+	if err != nil {
+		return err
+	}
+
+	current, err := parseVersion(currentVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse current version '%s': %w", currentVersion, err)
+	}
+	latest, err := parseVersion(release.TagName)
+	if err != nil {
+		return fmt.Errorf("failed to parse latest version tag '%s': %w", release.TagName, err)
+	}
+
+	if !current.lessThan(latest) {
+		console.Success("You are already using the latest version of tikwm (%s).", currentVersion)
+		return nil
+	}
+
+	console.Info("Updating from %s to %s...", currentVersion, release.TagName)
+
+	assetName := getAssetName()
+	var assetURL string
+	for _, asset := range release.Assets {
+		if asset.Name == assetName {
+			assetURL = asset.DownloadURL
+			break
+		}
+	}
+
+	if assetURL == "" {
+		return fmt.Errorf("could not find update asset '%s' for this platform", assetName)
+	}
+
+	console.Info("Downloading: %s", assetName)
+	resp, err := http.Get(assetURL) // #nosec G107
+	if err != nil {
+		return fmt.Errorf("failed to download asset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status downloading asset: %s", resp.Status)
+	}
+
+	bin, err := extractFileFromArchive(resp.Body, assetName)
+	if err != nil {
+		return fmt.Errorf("failed to extract binary: %w", err)
+	}
+
+	console.Info("Applying update...")
+	err = update.Apply(bin, update.Options{})
+	if err != nil {
+		return fmt.Errorf("update apply failed: %w", err)
+	}
+
+	console.Success("Successfully updated to version %s", release.TagName)
+	console.Info("If you executed a command other than 'update', please run your command again.")
+	return nil
+}

--- a/tools/tikwm/main.go
+++ b/tools/tikwm/main.go
@@ -7,12 +7,12 @@ import (
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/cmd"
 )
 
+var version string = "dev"
+
 func main() {
-	// Execute the command-line interface.
+	cmd.SetVersion(version)
 	if err := cmd.Execute(); err != nil {
-		// If an error occurs during command execution, print the error to stderr.
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		// Exit the program with a non-zero exit code to indicate failure.
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Introduce a self-update feature to the CLI.
Check for new versions on startup, then either notify the user or update automatically, based on new configuration options. Add `check_for_updates` (default: true) and `auto_update` (default: false) to the configuration file. Implement an `update` command to allow users to manually trigger the update process. On startup, notify users if a new version is available, prompting them to run `tikwm update`. If `auto_update` is enabled, the application will automatically download and apply the new version. The update check is skipped for lightweight commands like `edit`, `debug`, and `update` itself. Update the version injection mechanism to be handled via `main.go` to support the update logic. Fix a regression where the download directory was relative.

Closes #14