### PR TITLE
feat(cache): Implement simple time-based feed cache

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
 	DownloadAvatars bool   `koanf:"download_avatars"` // Download user profile avatars.
 	SavePostTitle   bool   `koanf:"save_post_title"`  // Save the post title to a .txt file.
 	FfmpegPath      string `koanf:"ffmpeg_path"`      // Path to the ffmpeg executable.
+	FeedCache       bool   `koanf:"feed_cache"`       // Enable caching of user feeds.
+	FeedCacheTTL    string `koanf:"feed_cache_ttl"`   // Time-to-live for feed cache (e.g., "1h", "30m").
 }
 
 // Default returns the default core configuration.
@@ -40,5 +42,7 @@ func Default() *Config {
 		DownloadAvatars: false,
 		SavePostTitle:   false,
 		FfmpegPath:      "ffmpeg",
+		FeedCache:       true,
+		FeedCacheTTL:    "1h",
 	}
 }

--- a/tools/tikwm/cmd/helpers.go
+++ b/tools/tikwm/cmd/helpers.go
@@ -60,6 +60,12 @@ func applyFlagOverrides(cmd *cobra.Command, cfg *cliconfig.Config) {
 	if cmd.Flag("save-post-title").Changed {
 		cfg.SavePostTitle, _ = cmd.Flags().GetBool("save-post-title")
 	}
+	if cmd.Flag("feed-cache").Changed {
+		cfg.FeedCache, _ = cmd.Flags().GetBool("feed-cache")
+	}
+	if cmd.Flag("feed-cache-ttl").Changed {
+		cfg.FeedCacheTTL, _ = cmd.Flags().GetString("feed-cache-ttl")
+	}
 }
 
 // getTargets retrieves targets from command-line arguments or a targets file.

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -203,6 +203,10 @@ func init() {
 	rootCmd.PersistentFlags().Bool("download-avatars", false, "Enable downloading of user avatars. Overrides config.")
 	rootCmd.PersistentFlags().Bool("save-post-title", false, "Save post title to a .txt file. Overrides config.")
 
+	// Caching flags
+	rootCmd.PersistentFlags().Bool("feed-cache", false, "Enable or disable caching of user feeds. Overrides config.")
+	rootCmd.PersistentFlags().String("feed-cache-ttl", "", `Time-to-live for feed cache, e.g., "1h", "30m". Overrides config.`)
+
 	// Add subcommands.
 	rootCmd.AddCommand(downloadCmd)
 	rootCmd.AddCommand(infoCmd)

--- a/tools/tikwm/internal/config/config.go
+++ b/tools/tikwm/internal/config/config.go
@@ -131,13 +131,21 @@ save_post_title: %t
 retry_on_429: %t
 # Path to the ffmpeg executable. Used to validate downloaded videos.
 ffmpeg_path: "%s"
+
+# Caching
+# Enable caching of user feeds to speed up repeated runs.
+feed_cache: %t
+# How long to keep feed cache before it's considered stale (e.g., "1h", "30m", "2h15m").
+feed_cache_ttl: "%s"
+
+# Other
 # Editor to use for the 'edit' command. If empty, it will check $EDITOR, then common editors.
 editor: "%s"
 # Check for new versions of tikwm on startup.
 check_for_updates: %t
 # Automatically install new versions of tikwm. If false, you will be notified to run 'tikwm update'.
 auto_update: %t
-`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
+`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.FeedCache, cfg.FeedCacheTTL, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
 	content = strings.ReplaceAll(content, "\\", "/")
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write default config file: %w", err)


### PR DESCRIPTION
Implement a simple, naive caching layer for user feeds to improve performance on subsequent runs. Introduce `feed_cache` and `feed_cache_ttl` config options, defaulting to true and "1h" respectively. Check for a non-expired cache in `getUserFeed` before fetching from the API. Cache files are stored as JSON in the standard user cache directory (e.g., `~/.cache/tikwm/feeds/`). Fetched feeds are written to the cache for future use. Cached feeds are still filtered against the current run's `--since` and other filter options.

Closes #43