### PR TITLE
feat(download): target file hot-reloading, daemon mode and --bind/ip rotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/fatih/color v1.18.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.0
@@ -18,7 +19,6 @@ require (
 )
 
 require (
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -152,7 +153,7 @@ func (c *Client) adoptLocalAsset(post *tikwm.Post, assetType tikwm.AssetType, lo
 }
 
 // DownloadPost downloads a single post by its URL.
-func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error {
+func (c *Client) DownloadPost(ctx context.Context, url string, force bool, logger *log.Logger) error {
 	post, err := tikwm.GetPost(url, true)
 	if err != nil {
 		return err
@@ -164,7 +165,7 @@ func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error 
 			return err
 		}
 		for _, assetType := range qualities {
-			if err := c.ensureVideoAsset(post, assetType, force, logger); err != nil {
+			if err := c.ensureVideoAsset(ctx, post, assetType, force, logger); err != nil {
 				logger.Printf("Could not process video for post %s (quality: %s): %v", post.ID(), assetType, err)
 				if errors.Is(err, tikwm.ErrDiskSpace) {
 					return err // Propagate fatal error
@@ -172,7 +173,7 @@ func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error 
 			}
 		}
 	} else if post.IsAlbum() {
-		if err := c.ensureAlbum(post, force, logger); err != nil {
+		if err := c.ensureAlbum(ctx, post, force, logger); err != nil {
 			logger.Printf("Could not process album for post %s: %v", post.ID(), err)
 			if errors.Is(err, tikwm.ErrDiskSpace) {
 				return err // Propagate fatal error
@@ -181,7 +182,7 @@ func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error 
 	}
 
 	if c.cfg.DownloadCovers {
-		if err := c.ensureCoverAsset(post, force, logger); err != nil {
+		if err := c.ensureCoverAsset(ctx, post, force, logger); err != nil {
 			logger.Printf("Could not download cover for post %s: %v", post.ID(), err)
 			if errors.Is(err, tikwm.ErrDiskSpace) {
 				return err // Propagate fatal error
@@ -189,7 +190,7 @@ func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error 
 		}
 	}
 	if c.cfg.DownloadAvatars {
-		if err := c.ensureAvatar(post, force, logger, make(map[string]bool)); err != nil {
+		if err := c.ensureAvatar(ctx, post, force, logger, make(map[string]bool)); err != nil {
 			logger.Printf("Could not download avatar for post %s: %v", post.Author.UniqueId, err)
 			if errors.Is(err, tikwm.ErrDiskSpace) {
 				return err // Propagate fatal error
@@ -200,7 +201,7 @@ func (c *Client) DownloadPost(url string, force bool, logger *log.Logger) error 
 }
 
 // DownloadProfile orchestrates the download of a user's entire profile with optimizations.
-func (c *Client) DownloadProfile(username string, force bool, logger *log.Logger, progressCb ProgressCallback) error {
+func (c *Client) DownloadProfile(ctx context.Context, username string, force bool, logger *log.Logger, progressCb ProgressCallback) error {
 	if progressCb == nil {
 		progressCb = noOpProgress
 	}
@@ -224,7 +225,7 @@ func (c *Client) DownloadProfile(username string, force bool, logger *log.Logger
 			progressCb(count, 0, fmt.Sprintf("%d posts found", count))
 		},
 	}
-	postChan, expectedCount, err := c.getUserFeed(username, feedOpt)
+	postChan, expectedCount, err := c.getUserFeed(ctx, username, feedOpt)
 	if err != nil {
 		return err
 	}
@@ -235,51 +236,67 @@ func (c *Client) DownloadProfile(username string, force bool, logger *log.Logger
 	}
 
 	i := 0
-	for postFromFeed := range postChan {
-		i++
-		postID := postFromFeed.ID()
-		progressCb(i, expectedCount, fmt.Sprintf("Checking %s", postID))
-		logger.Printf("--- Checking post %s (%d/%d) ---", postID, i, expectedCount)
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Printf("Profile download for %s cancelled.", username)
+			break loop
+		case postFromFeed, ok := <-postChan:
+			if !ok {
+				break loop // Channel closed, normal exit
+			}
+			i++
+			postID := postFromFeed.ID()
+			progressCb(i, expectedCount, fmt.Sprintf("Checking %s", postID))
+			logger.Printf("--- Checking post %s (%d/%d) ---", postID, i, expectedCount)
 
-		var procErr error
-		if postFromFeed.IsAlbum() {
-			procErr = c.processAlbumInFeed(&postFromFeed, force, logger, progressCb, i, expectedCount)
-		} else { // Is a video
-			procErr = c.processVideoInFeed(&postFromFeed, qualitiesNeeded, force, logger)
-		}
-		if procErr != nil {
-			if errors.Is(procErr, tikwm.ErrDiskSpace) {
-				return procErr // Abort profile download on fatal error
+			var procErr error
+			if postFromFeed.IsAlbum() {
+				procErr = c.processAlbumInFeed(ctx, &postFromFeed, force, logger, progressCb, i, expectedCount)
+			} else { // Is a video
+				procErr = c.processVideoInFeed(ctx, &postFromFeed, qualitiesNeeded, force, logger)
 			}
-			logger.Printf("Error processing post %s: %v. Continuing...", postID, procErr)
-		}
+			if procErr != nil {
+				if errors.Is(procErr, tikwm.ErrDiskSpace) || errors.Is(procErr, context.Canceled) {
+					return procErr // Abort profile download on fatal error
+				}
+				logger.Printf("Error processing post %s: %v. Continuing...", postID, procErr)
+			}
 
-		// Process cover for all post types
-		if c.cfg.DownloadCovers {
-			if err := c.processCoverInFeed(&postFromFeed, force, logger); err != nil {
-				if errors.Is(err, tikwm.ErrDiskSpace) {
-					return err // Abort profile download on fatal error
+			// Process cover for all post types
+			if c.cfg.DownloadCovers {
+				if err := c.processCoverInFeed(ctx, &postFromFeed, force, logger); err != nil {
+					if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
+						return err // Abort profile download on fatal error
+					}
+					logger.Printf("Error processing cover for post %s: %v. Continuing...", postID, err)
 				}
-				logger.Printf("Error processing cover for post %s: %v. Continuing...", postID, err)
+			}
+			// Process avatar once per author per run
+			if c.cfg.DownloadAvatars {
+				if err := c.ensureAvatar(ctx, &postFromFeed, force, logger, processedAvatars); err != nil {
+					if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
+						return err // Abort profile download on fatal error
+					}
+					// Log non-fatal avatar errors but continue
+					logger.Printf("Could not download avatar for %s: %v", postFromFeed.Author.UniqueId, err)
+				}
 			}
 		}
-		// Process avatar once per author per run
-		if c.cfg.DownloadAvatars {
-			if err := c.ensureAvatar(&postFromFeed, force, logger, processedAvatars); err != nil {
-				if errors.Is(err, tikwm.ErrDiskSpace) {
-					return err // Abort profile download on fatal error
-				}
-				// Log non-fatal avatar errors but continue
-				logger.Printf("Could not download avatar for %s: %v", postFromFeed.Author.UniqueId, err)
-			}
-		}
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 	progressCb(expectedCount, expectedCount, "Profile processing complete.")
 	return nil
 }
 
 // ensureAvatar handles downloading a user's avatar if it's new.
-func (c *Client) ensureAvatar(post *tikwm.Post, force bool, logger *log.Logger, processed map[string]bool) error {
+func (c *Client) ensureAvatar(ctx context.Context, post *tikwm.Post, force bool, logger *log.Logger, processed map[string]bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	authorID := post.Author.UniqueId
 	if _, ok := processed[authorID]; ok {
 		return nil // Already handled this author in this session
@@ -359,21 +376,21 @@ func (c *Client) savePostTitle(post *tikwm.Post, logger *log.Logger) error {
 }
 
 // processVideoInFeed handles video-specific processing within the feed.
-func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []tikwm.AssetType, force bool, logger *log.Logger) error {
+func (c *Client) processVideoInFeed(ctx context.Context, postFromFeed *tikwm.Post, qualitiesNeeded []tikwm.AssetType, force bool, logger *log.Logger) error {
 	postID := postFromFeed.ID()
 	validator := tikwm.ValidateWithFfmpeg(c.cfg.FfmpegPath)
 
 	if force {
 		logger.Printf("Force enabled for %s. Fetching full details to download all qualities.", postID)
-		fullPost, err := c.getPostWithRetry(postFromFeed, noOpProgress, 0, 0)
+		fullPost, err := c.getPostWithRetry(ctx, postFromFeed, noOpProgress, 0, 0)
 		if err != nil {
 			logger.Printf("Failed to get full post details for %s: %v", postID, err)
-			return nil // Continue with other posts
+			return err
 		}
 		for _, quality := range qualitiesNeeded {
-			if err := c.ensureVideoAsset(fullPost, quality, true, logger); err != nil {
+			if err := c.ensureVideoAsset(ctx, fullPost, quality, true, logger); err != nil {
 				logger.Printf("Error during forced download for %s (quality: %s): %v", postID, quality, err)
-				if errors.Is(err, tikwm.ErrDiskSpace) {
+				if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 					return err
 				}
 			}
@@ -382,6 +399,9 @@ func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []
 	}
 
 	for _, quality := range qualitiesNeeded {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if exists, _ := c.db.AssetExists(postID, quality); exists {
 			continue
 		}
@@ -389,9 +409,9 @@ func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []
 		exists, size, err := c.checkLocalAsset(postFromFeed, quality, logger)
 		if err != nil {
 			logger.Printf("Error checking local asset for %s (quality: %s): %v. Will attempt download.", postID, quality, err)
-			if err := c.ensureVideoAsset(postFromFeed, quality, true, logger); err != nil {
+			if err := c.ensureVideoAsset(ctx, postFromFeed, quality, true, logger); err != nil {
 				logger.Printf("Error downloading video for %s: %v", postID, err)
-				if errors.Is(err, tikwm.ErrDiskSpace) {
+				if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 					return err
 				}
 			}
@@ -400,9 +420,9 @@ func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []
 
 		if !exists {
 			logger.Printf("Asset for %s (quality: %s) not found. Downloading.", postID, quality)
-			if err := c.ensureVideoAsset(postFromFeed, quality, true, logger); err != nil {
+			if err := c.ensureVideoAsset(ctx, postFromFeed, quality, true, logger); err != nil {
 				logger.Printf("Error downloading video for %s: %v", postID, err)
-				if errors.Is(err, tikwm.ErrDiskSpace) {
+				if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 					return err
 				}
 			}
@@ -440,9 +460,9 @@ func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []
 			}
 		} else {
 			// If we decided not to adopt for any reason (bad size, failed validation), re-download.
-			if err := c.ensureVideoAsset(postFromFeed, quality, true, logger); err != nil {
+			if err := c.ensureVideoAsset(ctx, postFromFeed, quality, true, logger); err != nil {
 				logger.Printf("Error re-downloading video for %s: %v", postID, err)
-				if errors.Is(err, tikwm.ErrDiskSpace) {
+				if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 					return err
 				}
 			}
@@ -452,7 +472,7 @@ func (c *Client) processVideoInFeed(postFromFeed *tikwm.Post, qualitiesNeeded []
 }
 
 // ensureVideoAsset handles the logic for making sure a video asset exists on disk and is recorded in the database.
-func (c *Client) ensureVideoAsset(post *tikwm.Post, assetType tikwm.AssetType, force bool, logger *log.Logger) error {
+func (c *Client) ensureVideoAsset(ctx context.Context, post *tikwm.Post, assetType tikwm.AssetType, force bool, logger *log.Logger) error {
 	if !force {
 		exists, err := c.db.AssetExists(post.ID(), assetType)
 		if err != nil {
@@ -465,7 +485,7 @@ func (c *Client) ensureVideoAsset(post *tikwm.Post, assetType tikwm.AssetType, f
 	}
 	logger.Printf("Processing video asset for post %s (quality: %s)...", post.ID(), assetType)
 
-	_, sha, err := c.downloadVideo(post, assetType, tikwm.DownloadOpt{Directory: c.cfg.DownloadPath, FfmpegPath: c.cfg.FfmpegPath})
+	_, sha, err := c.downloadVideo(ctx, post, assetType, tikwm.DownloadOpt{Directory: c.cfg.DownloadPath, FfmpegPath: c.cfg.FfmpegPath})
 	if err != nil {
 		return err
 	}
@@ -480,7 +500,7 @@ func (c *Client) ensureVideoAsset(post *tikwm.Post, assetType tikwm.AssetType, f
 	return c.savePostTitle(post, logger)
 }
 
-func (c *Client) ensureCoverAsset(post *tikwm.Post, force bool, logger *log.Logger) error {
+func (c *Client) ensureCoverAsset(ctx context.Context, post *tikwm.Post, force bool, logger *log.Logger) error {
 	assetType, coverURL := c.getCoverAssetType(post)
 	if coverURL == "" {
 		return fmt.Errorf("no URL found for configured cover type '%s' on post %s", c.cfg.CoverType, post.ID())
@@ -512,20 +532,20 @@ func (c *Client) ensureCoverAsset(post *tikwm.Post, force bool, logger *log.Logg
 	return c.db.AddOrUpdateAsset(post.ID(), post.Author.UniqueId, post.CreateTime, assetType, sha)
 }
 
-func (c *Client) processCoverInFeed(post *tikwm.Post, force bool, logger *log.Logger) error {
+func (c *Client) processCoverInFeed(ctx context.Context, post *tikwm.Post, force bool, logger *log.Logger) error {
 	if !c.cfg.DownloadCovers {
 		return nil
 	}
-	if err := c.ensureCoverAsset(post, force, logger); err != nil {
+	if err := c.ensureCoverAsset(ctx, post, force, logger); err != nil {
 		logger.Printf("Could not process cover for post %s: %v", post.ID(), err)
-		if errors.Is(err, tikwm.ErrDiskSpace) {
+		if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *Client) processAlbumInFeed(post *tikwm.Post, force bool, logger *log.Logger, progressCb ProgressCallback, current, total int) error {
+func (c *Client) processAlbumInFeed(ctx context.Context, post *tikwm.Post, force bool, logger *log.Logger, progressCb ProgressCallback, current, total int) error {
 	postID := post.ID()
 	totalPhotosInAlbum := len(post.Images)
 	if totalPhotosInAlbum == 0 {
@@ -537,7 +557,7 @@ func (c *Client) processAlbumInFeed(post *tikwm.Post, force bool, logger *log.Lo
 		countInDb, err := c.db.GetAlbumPhotoCount(postID)
 		if err != nil {
 			logger.Printf("DB check failed for album %s: %v", postID, err)
-			return nil // Continue with other posts
+			return err // Continue with other posts
 		}
 		if countInDb >= totalPhotosInAlbum {
 			progressCb(current, total, fmt.Sprintf("Album %s complete", postID))
@@ -548,10 +568,10 @@ func (c *Client) processAlbumInFeed(post *tikwm.Post, force bool, logger *log.Lo
 
 	// Album needs processing. Fetch full details to ensure data is fresh.
 	logger.Printf("Album %s requires processing. Fetching full post details.", postID)
-	finalPost, fetchErr := c.getPostWithRetry(post, progressCb, current, total)
+	finalPost, fetchErr := c.getPostWithRetry(ctx, post, progressCb, current, total)
 	if fetchErr != nil {
 		logger.Printf("Failed to get full post details for %s: %v", postID, fetchErr)
-		return nil // Continue with other posts
+		return fetchErr
 	}
 
 	if !finalPost.IsAlbum() || len(finalPost.Images) == 0 {
@@ -559,9 +579,9 @@ func (c *Client) processAlbumInFeed(post *tikwm.Post, force bool, logger *log.Lo
 		return nil
 	}
 
-	if err := c.ensureAlbum(finalPost, force, logger); err != nil {
+	if err := c.ensureAlbum(ctx, finalPost, force, logger); err != nil {
 		logger.Printf("Error processing album for post %s: %v", postID, err)
-		if errors.Is(err, tikwm.ErrDiskSpace) {
+		if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 			return err
 		}
 	}
@@ -569,7 +589,7 @@ func (c *Client) processAlbumInFeed(post *tikwm.Post, force bool, logger *log.Lo
 }
 
 // ensureAlbum handles the logic for downloading all photos in an album and recording them in the database.
-func (c *Client) ensureAlbum(post *tikwm.Post, force bool, logger *log.Logger) error {
+func (c *Client) ensureAlbum(ctx context.Context, post *tikwm.Post, force bool, logger *log.Logger) error {
 	logger.Printf("Processing album for post %s (%d images)...", post.ID(), len(post.Images))
 
 	// Migration: Delete old single-row entry for this album if it exists.
@@ -582,6 +602,10 @@ func (c *Client) ensureAlbum(post *tikwm.Post, force bool, logger *log.Logger) e
 		photoIndex := i   // 0-based for array access
 		photoNum := i + 1 // 1-based for ID
 		albumPhotoID := fmt.Sprintf("%s_%d_%d", post.ID(), photoNum, len(post.Images))
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
 		if !force {
 			exists, err := c.db.AssetExists(albumPhotoID, tikwm.AssetAlbumPhoto)
@@ -597,10 +621,10 @@ func (c *Client) ensureAlbum(post *tikwm.Post, force bool, logger *log.Logger) e
 
 		logger.Printf("Processing photo %d/%d for post %s.", photoNum, len(post.Images), post.ID())
 
-		_, sha, err := c.downloadAlbumPhoto(post, photoIndex, tikwm.DownloadOpt{Directory: c.cfg.DownloadPath})
+		_, sha, err := c.downloadAlbumPhoto(ctx, post, photoIndex, tikwm.DownloadOpt{Directory: c.cfg.DownloadPath})
 		if err != nil {
 			logger.Printf("Failed to download photo %s: %v", albumPhotoID, err)
-			if errors.Is(err, tikwm.ErrDiskSpace) {
+			if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
 				return err // Propagate fatal error
 			}
 			continue
@@ -622,7 +646,7 @@ func (c *Client) ensureAlbum(post *tikwm.Post, force bool, logger *log.Logger) e
 }
 
 // DownloadCoversForUser downloads missing covers for all posts by a user.
-func (c *Client) DownloadCoversForUser(username string, logger *log.Logger, progressCb ProgressCallback) error {
+func (c *Client) DownloadCoversForUser(ctx context.Context, username string, logger *log.Logger, progressCb ProgressCallback) error {
 	if progressCb == nil {
 		progressCb = noOpProgress
 	}
@@ -636,23 +660,31 @@ func (c *Client) DownloadCoversForUser(username string, logger *log.Logger, prog
 		return nil
 	}
 	for i, record := range posts {
-		progressCb(i+1, len(posts), "Checking post "+record.ID)
-		if record.HasCover {
-			continue
-		}
-		// Album photo entries have composite IDs and won't be processed here, which is correct.
-		if strings.Contains(record.ID, "_") {
-			continue
-		}
-		post, err := c.getPostWithRetry(&tikwm.Post{Id: record.ID}, progressCb, i+1, len(posts))
-		if err != nil {
-			logger.Printf("Could not get post details for %s: %v", record.ID, err)
-			continue
-		}
-		if err := c.ensureCoverAsset(post, false, logger); err != nil {
-			logger.Printf("Could not download cover for post %s: %v", post.ID(), err)
-			if errors.Is(err, tikwm.ErrDiskSpace) {
-				return err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			progressCb(i+1, len(posts), "Checking post "+record.ID)
+			if record.HasCover {
+				continue
+			}
+			// Album photo entries have composite IDs and won't be processed here, which is correct.
+			if strings.Contains(record.ID, "_") {
+				continue
+			}
+			post, err := c.getPostWithRetry(ctx, &tikwm.Post{Id: record.ID}, progressCb, i+1, len(posts))
+			if err != nil {
+				logger.Printf("Could not get post details for %s: %v", record.ID, err)
+				if errors.Is(err, context.Canceled) {
+					return err
+				}
+				continue
+			}
+			if err := c.ensureCoverAsset(ctx, post, false, logger); err != nil {
+				logger.Printf("Could not download cover for post %s: %v", post.ID(), err)
+				if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
+					return err
+				}
 			}
 		}
 	}
@@ -660,7 +692,7 @@ func (c *Client) DownloadCoversForUser(username string, logger *log.Logger, prog
 }
 
 // FixProfile downloads videos for a user that are present in the database but are missing the desired asset.
-func (c *Client) FixProfile(username string, logger *log.Logger, progressCb ProgressCallback) error {
+func (c *Client) FixProfile(ctx context.Context, username string, logger *log.Logger, progressCb ProgressCallback) error {
 	if progressCb == nil {
 		progressCb = noOpProgress
 	}
@@ -680,16 +712,24 @@ func (c *Client) FixProfile(username string, logger *log.Logger, progressCb Prog
 		}
 		progressCb(0, len(missingPosts), fmt.Sprintf("Found %d missing %s videos.", len(missingPosts), assetType))
 		for i, record := range missingPosts {
-			progressCb(i+1, len(missingPosts), "Processing "+record.ID)
-			post, err := c.getPostWithRetry(&tikwm.Post{Id: record.ID}, progressCb, i+1, len(missingPosts))
-			if err != nil {
-				logger.Printf("Could not get post details for %s: %v", record.ID, err)
-				continue
-			}
-			if err := c.ensureVideoAsset(post, assetType, true, logger); err != nil {
-				logger.Printf("Failed to process video for post %s (quality: %s): %v", post.ID(), assetType, err)
-				if errors.Is(err, tikwm.ErrDiskSpace) {
-					return err
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				progressCb(i+1, len(missingPosts), "Processing "+record.ID)
+				post, err := c.getPostWithRetry(ctx, &tikwm.Post{Id: record.ID}, progressCb, i+1, len(missingPosts))
+				if err != nil {
+					logger.Printf("Could not get post details for %s: %v", record.ID, err)
+					if errors.Is(err, context.Canceled) {
+						return err
+					}
+					continue
+				}
+				if err := c.ensureVideoAsset(ctx, post, assetType, true, logger); err != nil {
+					logger.Printf("Failed to process video for post %s (quality: %s): %v", post.ID(), assetType, err)
+					if errors.Is(err, tikwm.ErrDiskSpace) || errors.Is(err, context.Canceled) {
+						return err
+					}
 				}
 			}
 		}
@@ -697,27 +737,36 @@ func (c *Client) FixProfile(username string, logger *log.Logger, progressCb Prog
 	return nil
 }
 
-func (c *Client) getPostWithRetry(post *tikwm.Post, progressCb ProgressCallback, current, total int) (*tikwm.Post, error) {
+func (c *Client) getPostWithRetry(ctx context.Context, post *tikwm.Post, progressCb ProgressCallback, current, total int) (*tikwm.Post, error) {
 	if progressCb == nil {
 		progressCb = noOpProgress
 	}
 	maxRetries := 5
 	for i := 0; i < maxRetries; i++ {
-		progressCb(current, total, "Fetching post details for "+post.ID())
-		hdPost, err := tikwm.GetPost(post.ID(), true)
-		if err != nil {
-			if strings.Contains(err.Error(), "(-1)") || strings.Contains(err.Error(), "Free Api Limit") || strings.Contains(err.Error(), "(429)") {
-				if !c.cfg.RetryOn429 {
-					return nil, fmt.Errorf("rate limited fetching post %s, aborting. Enable --retry-on-429 to retry", post.ID())
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			progressCb(current, total, "Fetching post details for "+post.ID())
+			hdPost, err := tikwm.GetPost(post.ID(), true)
+			if err != nil {
+				if strings.Contains(err.Error(), "(-1)") || strings.Contains(err.Error(), "Free Api Limit") || strings.Contains(err.Error(), "(429)") {
+					if !c.cfg.RetryOn429 {
+						return nil, fmt.Errorf("rate limited fetching post %s, aborting. Enable --retry-on-429 to retry", post.ID())
+					}
+					wait := time.Second * time.Duration(2<<i) // Exponential backoff: 2s, 4s, 8s...
+					progressCb(current, total, fmt.Sprintf("Rate limited. Retrying in %s...", wait))
+					select {
+					case <-time.After(wait):
+						continue
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
 				}
-				wait := time.Second * time.Duration(2<<i) // Exponential backoff: 2s, 4s, 8s...
-				progressCb(current, total, fmt.Sprintf("Rate limited. Retrying in %s...", wait))
-				time.Sleep(wait)
-				continue
+				return nil, err
 			}
-			return nil, err
+			return hdPost, nil
 		}
-		return hdPost, nil
 	}
 	return nil, fmt.Errorf("failed to get details for %s after %d retries", post.ID(), maxRetries)
 }
@@ -725,7 +774,7 @@ func (c *Client) getPostWithRetry(post *tikwm.Post, progressCb ProgressCallback,
 // --- New Download Logic ---
 
 // downloadVideo downloads a specific quality of a video post.
-func (c *Client) downloadVideo(post *tikwm.Post, assetType tikwm.AssetType, opts ...tikwm.DownloadOpt) (file string, sha256 string, err error) {
+func (c *Client) downloadVideo(ctx context.Context, post *tikwm.Post, assetType tikwm.AssetType, opts ...tikwm.DownloadOpt) (file string, sha256 string, err error) {
 	switch assetType {
 	case tikwm.AssetHD, tikwm.AssetSD, tikwm.AssetSource:
 		// Valid types
@@ -746,7 +795,7 @@ func (c *Client) downloadVideo(post *tikwm.Post, assetType tikwm.AssetType, opts
 	}
 
 	filename := path.Join(creatorDir, opt.FilenameFormat(post, 0, assetType))
-	if err := c.downloadRetrying(post, assetType, filename, 0, nil, opt); err != nil {
+	if err := c.downloadRetrying(ctx, post, assetType, filename, 0, nil, opt); err != nil {
 		return "", "", err
 	}
 	hash, err := tikwm.FileSHA256(filename)
@@ -758,7 +807,7 @@ func (c *Client) downloadVideo(post *tikwm.Post, assetType tikwm.AssetType, opts
 }
 
 // downloadAlbumPhoto downloads a single photo from an album post at a specific index.
-func (c *Client) downloadAlbumPhoto(post *tikwm.Post, index int, opts ...tikwm.DownloadOpt) (file string, sha256 string, err error) {
+func (c *Client) downloadAlbumPhoto(ctx context.Context, post *tikwm.Post, index int, opts ...tikwm.DownloadOpt) (file string, sha256 string, err error) {
 	if !post.IsAlbum() {
 		return "", "", fmt.Errorf("post %s is not an album", post.ID())
 	}
@@ -784,7 +833,7 @@ func (c *Client) downloadAlbumPhoto(post *tikwm.Post, index int, opts ...tikwm.D
 	// Create a copy of the post for the retry logic to avoid race conditions if used concurrently.
 	imgPost := *post
 	// Pass the direct URL as a temporary "AssetType" for the retry logic.
-	if err := c.downloadRetrying(&imgPost, tikwm.AssetType(url), filename, 0, nil, opt); err != nil {
+	if err := c.downloadRetrying(ctx, &imgPost, tikwm.AssetType(url), filename, 0, nil, opt); err != nil {
 		return "", "", err
 	}
 
@@ -797,7 +846,10 @@ func (c *Client) downloadAlbumPhoto(post *tikwm.Post, index int, opts ...tikwm.D
 }
 
 // downloadRetrying attempts to download a file with retries and post refresh on failures.
-func (c *Client) downloadRetrying(post *tikwm.Post, assetType tikwm.AssetType, filename string, try int, lastErr error, opt *tikwm.DownloadOpt) error {
+func (c *Client) downloadRetrying(ctx context.Context, post *tikwm.Post, assetType tikwm.AssetType, filename string, try int, lastErr error, opt *tikwm.DownloadOpt) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if try > opt.Retries {
 		finalErr := lastErr
 		if finalErr == nil {
@@ -807,11 +859,16 @@ func (c *Client) downloadRetrying(post *tikwm.Post, assetType tikwm.AssetType, f
 	}
 
 	if try > 0 {
-		time.Sleep(opt.TimeoutOnError)
+		select {
+		case <-time.After(opt.TimeoutOnError):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
 		if assetType == tikwm.AssetHD || assetType == tikwm.AssetSD {
-			refreshedPost, refreshErr := c.getPostWithRetry(post, nil, 0, 0) // No progress CB for internal retries
+			refreshedPost, refreshErr := c.getPostWithRetry(ctx, post, nil, 0, 0) // No progress CB for internal retries
 			if refreshErr != nil {
-				return c.downloadRetrying(post, assetType, filename, try+1, refreshErr, opt)
+				return c.downloadRetrying(ctx, post, assetType, filename, try+1, refreshErr, opt)
 			}
 			*post = *refreshedPost
 		}
@@ -819,7 +876,7 @@ func (c *Client) downloadRetrying(post *tikwm.Post, assetType tikwm.AssetType, f
 
 	url, size, err := c.getURLAndSizeForAsset(post, assetType)
 	if err != nil {
-		return c.downloadRetrying(post, assetType, filename, try+1, err, opt)
+		return c.downloadRetrying(ctx, post, assetType, filename, try+1, err, opt)
 	}
 
 	requiredSpace := uint64(0)
@@ -838,18 +895,18 @@ func (c *Client) downloadRetrying(post *tikwm.Post, assetType tikwm.AssetType, f
 	}
 
 	if url == "" {
-		return c.downloadRetrying(post, assetType, filename, try+1, fmt.Errorf("URL for asset type %s is missing", assetType), opt)
+		return c.downloadRetrying(ctx, post, assetType, filename, try+1, fmt.Errorf("URL for asset type %s is missing", assetType), opt)
 	}
 
 	if err := opt.DownloadWith(url, filename); err != nil {
-		return c.downloadRetrying(post, assetType, filename, try+1, err, opt)
+		return c.downloadRetrying(ctx, post, assetType, filename, try+1, err, opt)
 	}
 
 	if post.IsVideo() {
 		if valid, err := opt.ValidateWith(filename); err != nil {
-			return c.downloadRetrying(post, assetType, filename, try+1, err, opt)
+			return c.downloadRetrying(ctx, post, assetType, filename, try+1, err, opt)
 		} else if !valid {
-			return c.downloadRetrying(post, assetType, filename, try+1, fmt.Errorf("validation failed for %s", filename), opt)
+			return c.downloadRetrying(ctx, post, assetType, filename, try+1, fmt.Errorf("validation failed for %s", filename), opt)
 		}
 	}
 	return nil
@@ -881,7 +938,7 @@ func (c *Client) getURLAndSizeForAsset(post *tikwm.Post, assetType tikwm.AssetTy
 
 // getUserFeed fetches the user feed and returns a channel to which posts are sent.
 // It implements a simple, time-based cache to speed up repeated runs.
-func (c *Client) getUserFeed(uniqueID string, opt *tikwm.FeedOpt) (chan tikwm.Post, int, error) {
+func (c *Client) getUserFeed(ctx context.Context, uniqueID string, opt *tikwm.FeedOpt) (chan tikwm.Post, int, error) {
 	opt = opt.Defaults()
 
 	if c.cfg.FeedCache {
@@ -895,7 +952,7 @@ func (c *Client) getUserFeed(uniqueID string, opt *tikwm.FeedOpt) (chan tikwm.Po
 	}
 
 	// Fetch from API if cache is disabled, missed, or failed
-	allPosts, err := c.userFeedSinceInternal(uniqueID, "0", opt, 0)
+	allPosts, err := c.userFeedSinceInternal(ctx, uniqueID, "0", opt, 0)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1008,15 +1065,25 @@ func (c *Client) getFeedCachePath(username string) (string, error) {
 }
 
 // userFeedSinceInternal is a recursive function that fetches user feed posts since a given cursor.
-func (c *Client) userFeedSinceInternal(uniqueID string, cursor string, opt *tikwm.FeedOpt, currentCount int) ([]tikwm.Post, error) {
+func (c *Client) userFeedSinceInternal(ctx context.Context, uniqueID string, cursor string, opt *tikwm.FeedOpt, currentCount int) ([]tikwm.Post, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	feed, err := tikwm.GetUserFeedRaw(uniqueID, tikwm.MaxUserFeedCount, cursor)
 	if err != nil {
 		// Specific handling for rate limit errors
 		if strings.Contains(err.Error(), "(-1)") || strings.Contains(err.Error(), "Free Api Limit") || strings.Contains(err.Error(), "(429)") {
 			if c.cfg.RetryOn429 {
 				opt.OnError(fmt.Errorf("rate limited, retrying feed from cursor %s", cursor))
-				time.Sleep(2 * time.Second) // Wait and retry the same request
-				return c.userFeedSinceInternal(uniqueID, cursor, opt, currentCount)
+				select {
+				case <-time.After(2 * time.Second): // Wait and retry the same request
+					return c.userFeedSinceInternal(ctx, uniqueID, cursor, opt, currentCount)
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
 			}
 		}
 		return nil, err
@@ -1040,7 +1107,7 @@ func (c *Client) userFeedSinceInternal(uniqueID string, cursor string, opt *tikw
 	if !feed.HasMore {
 		return ret, nil
 	}
-	deeperRet, err := c.userFeedSinceInternal(uniqueID, feed.Cursor, opt, newTotal)
+	deeperRet, err := c.userFeedSinceInternal(ctx, uniqueID, feed.Cursor, opt, newTotal)
 	if err != nil {
 		return ret, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	FfmpegPath      string `koanf:"ffmpeg_path"`      // Path to the ffmpeg executable.
 	FeedCache       bool   `koanf:"feed_cache"`       // Enable caching of user feeds.
 	FeedCacheTTL    string `koanf:"feed_cache_ttl"`   // Time-to-live for feed cache (e.g., "1h", "30m").
+	BindAddress     string `koanf:"bind_address"`     // Outbound IP address or interface to bind to.
 }
 
 // Default returns the default core configuration.
@@ -44,5 +45,6 @@ func Default() *Config {
 		FfmpegPath:      "ffmpeg",
 		FeedCache:       true,
 		FeedCacheTTL:    "1h",
+		BindAddress:     "", // Default is to let the OS decide.
 	}
 }

--- a/pkg/network/ip_rotator.go
+++ b/pkg/network/ip_rotator.go
@@ -1,0 +1,150 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// activeAddress represents a resolvable local address for network binding.
+type activeAddress struct {
+	addr *net.TCPAddr
+}
+
+// ipState tracks the status of a configured bind address.
+type ipState struct {
+	address     *activeAddress
+	isExhausted bool
+	exhaustedAt time.Time
+}
+
+// IPRotator manages a pool of bind addresses, handling rotation and rate-limit fallback.
+type IPRotator struct {
+	mu            sync.RWMutex
+	addresses     []*ipState
+	currentIndex  int
+	exhaustionTTL time.Duration
+	lastUsed      *net.TCPAddr
+}
+
+// NewIPRotator creates and initializes a new IPRotator.
+// It resolves and validates all provided addresses.
+func NewIPRotator(bindAddresses string, exhaustionTTL time.Duration) (*IPRotator, error) {
+	if strings.TrimSpace(bindAddresses) == "" {
+		return nil, fmt.Errorf("bind addresses cannot be empty")
+	}
+
+	parts := strings.Split(bindAddresses, ",")
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("no valid bind addresses found")
+	}
+
+	rotator := &IPRotator{
+		addresses:     make([]*ipState, 0, len(parts)),
+		exhaustionTTL: exhaustionTTL,
+	}
+
+	for _, part := range parts {
+		trimmedPart := strings.TrimSpace(part)
+		if trimmedPart == "" {
+			continue
+		}
+		tcpAddr, err := resolveBindAddr(trimmedPart)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve bind address '%s': %w", trimmedPart, err)
+		}
+		rotator.addresses = append(rotator.addresses, &ipState{
+			address: &activeAddress{addr: tcpAddr},
+		})
+	}
+
+	if len(rotator.addresses) == 0 {
+		return nil, fmt.Errorf("no usable addresses could be resolved from '%s'", bindAddresses)
+	}
+
+	return rotator, nil
+}
+
+// GetNextAvailableAddress finds the next non-exhausted address for use, cycling through the list.
+func (r *IPRotator) GetNextAvailableAddress() (*net.TCPAddr, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.addresses) == 0 {
+		return nil, fmt.Errorf("no addresses configured in rotator")
+	}
+
+	// Un-exhaust any IPs whose TTL has expired.
+	for _, state := range r.addresses {
+		if state.isExhausted && time.Since(state.exhaustedAt) > r.exhaustionTTL {
+			state.isExhausted = false
+		}
+	}
+
+	// Starting from the current index, find the next available address.
+	for i := 0; i < len(r.addresses); i++ {
+		idx := (r.currentIndex + i) % len(r.addresses)
+		if !r.addresses[idx].isExhausted {
+			addr := r.addresses[idx].address.addr
+			r.currentIndex = (idx + 1) % len(r.addresses)
+			r.lastUsed = addr
+			return addr, nil
+		}
+	}
+
+	return nil, fmt.Errorf("all available IP addresses are currently rate-limited")
+}
+
+// MarkCurrentAddressAsExhausted flags the most recently used IP as rate-limited.
+func (r *IPRotator) MarkCurrentAddressAsExhausted() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.lastUsed == nil {
+		return
+	}
+
+	for _, state := range r.addresses {
+		if state.address.addr.String() == r.lastUsed.String() {
+			state.isExhausted = true
+			state.exhaustedAt = time.Now()
+			break
+		}
+	}
+}
+
+// resolveBindAddr takes a string that can be an IP address or an interface name
+// and returns a resolvable *net.TCPAddr.
+func resolveBindAddr(addrOrInterface string) (*net.TCPAddr, error) {
+	ip := net.ParseIP(addrOrInterface)
+	if ip != nil {
+		return &net.TCPAddr{IP: ip}, nil
+	}
+
+	iface, err := net.InterfaceByName(addrOrInterface)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find network interface '%s': %w", addrOrInterface, err)
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil || len(addrs) == 0 {
+		return nil, fmt.Errorf("interface '%s' has no usable addresses", addrOrInterface)
+	}
+
+	for _, addr := range addrs {
+		var ip net.IP
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			ip = ipNet.IP
+		} else if ipAddr, ok := addr.(*net.IPAddr); ok {
+			ip = ipAddr.IP
+		}
+
+		if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
+			return &net.TCPAddr{IP: ip}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no usable IPv4 address found for interface '%s'", addrOrInterface)
+}

--- a/pkg/network/manager.go
+++ b/pkg/network/manager.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var (
+	// globalRotator is the instance that manages IP addresses.
+	globalRotator *IPRotator
+)
+
+// InitManager initializes the global network manager with IP rotation capabilities.
+// It replaces the http.DefaultTransport with a custom one if bind addresses are provided.
+func InitManager(bindAddresses string) error {
+	if strings.TrimSpace(bindAddresses) == "" {
+		// No custom binding, use default transport.
+		return nil
+	}
+
+	var err error
+	// The per-IP daily limit is 24 hours.
+	globalRotator, err = NewIPRotator(bindAddresses, 24*time.Hour)
+	if err != nil {
+		return err
+	}
+
+	// Create a transport that gets its dialer dynamically from the rotator.
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			nextAddr, err := globalRotator.GetNextAvailableAddress()
+			if err != nil {
+				return nil, err // All IPs are exhausted
+			}
+			dialer := &net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				LocalAddr: nextAddr,
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// Set the custom transport as the default for all HTTP clients.
+	http.DefaultClient = &http.Client{Transport: transport}
+	return nil
+}
+
+// MarkCurrentAddressAsExhausted signals the global rotator to mark the last-used IP as exhausted.
+func MarkCurrentAddressAsExhausted() {
+	if globalRotator != nil {
+		globalRotator.MarkCurrentAddressAsExhausted()
+	}
+}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -25,47 +25,47 @@ func GetGlobalTransport() http.RoundTripper {
 	return http.DefaultTransport
 }
 
-// resolveBindAddr takes a string that can be an IP address or an interface name
-// and returns a resolvable *net.TCPAddr.
-func resolveBindAddr(addrOrInterface string) (*net.TCPAddr, error) {
-	// First, try to parse as an IP address directly.
-	ip := net.ParseIP(addrOrInterface)
-	if ip != nil {
-		return &net.TCPAddr{IP: ip}, nil
-	}
+// // resolveBindAddr takes a string that can be an IP address or an interface name
+// // and returns a resolvable *net.TCPAddr.
+// func resolveBindAddr(addrOrInterface string) (*net.TCPAddr, error) {
+// 	// First, try to parse as an IP address directly.
+// 	ip := net.ParseIP(addrOrInterface)
+// 	if ip != nil {
+// 		return &net.TCPAddr{IP: ip}, nil
+// 	}
 
-	// If it's not a valid IP, assume it's an interface name.
-	iface, err := net.InterfaceByName(addrOrInterface)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find network interface '%s': %w", addrOrInterface, err)
-	}
+// 	// If it's not a valid IP, assume it's an interface name.
+// 	iface, err := net.InterfaceByName(addrOrInterface)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to find network interface '%s': %w", addrOrInterface, err)
+// 	}
 
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get addresses for interface '%s': %w", addrOrInterface, err)
-	}
-	if len(addrs) == 0 {
-		return nil, fmt.Errorf("network interface '%s' has no addresses", addrOrInterface)
-	}
+// 	addrs, err := iface.Addrs()
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to get addresses for interface '%s': %w", addrOrInterface, err)
+// 	}
+// 	if len(addrs) == 0 {
+// 		return nil, fmt.Errorf("network interface '%s' has no addresses", addrOrInterface)
+// 	}
 
-	// Find the first usable IPv4 address on the interface.
-	for _, addr := range addrs {
-		var ip net.IP
-		// The addr is of type net.Addr, which can be *net.IPNet or *net.IPAddr.
-		// We need to check and extract the IP.
-		if ipNet, ok := addr.(*net.IPNet); ok {
-			ip = ipNet.IP
-		} else if ipAddr, ok := addr.(*net.IPAddr); ok {
-			ip = ipAddr.IP
-		}
+// 	// Find the first usable IPv4 address on the interface.
+// 	for _, addr := range addrs {
+// 		var ip net.IP
+// 		// The addr is of type net.Addr, which can be *net.IPNet or *net.IPAddr.
+// 		// We need to check and extract the IP.
+// 		if ipNet, ok := addr.(*net.IPNet); ok {
+// 			ip = ipNet.IP
+// 		} else if ipAddr, ok := addr.(*net.IPAddr); ok {
+// 			ip = ipAddr.IP
+// 		}
 
-		if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
-			return &net.TCPAddr{IP: ip}, nil
-		}
-	}
+// 		if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
+// 			return &net.TCPAddr{IP: ip}, nil
+// 		}
+// 	}
 
-	return nil, fmt.Errorf("no usable IPv4 address found for interface '%s'", addrOrInterface)
-}
+// 	return nil, fmt.Errorf("no usable IPv4 address found for interface '%s'", addrOrInterface)
+// }
 
 // NewHTTPTransport creates a new http.Transport that binds to the specified local address.
 func NewHTTPTransport(bindAddr string) (*http.Transport, error) {

--- a/tools/tikwm/cmd/covers.go
+++ b/tools/tikwm/cmd/covers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/perpetuallyhorni/tikwm/pkg/client"
@@ -25,6 +26,7 @@ var coversCmd = &cobra.Command{
 		for _, target := range targets {
 			username := client.ExtractUsername(target) // Capture for closure
 			workerPool.Submit(func() {
+				ctx := context.Background()
 				console.AddTask(username, "Checking for missing covers...", cli.OpFeedFetch)
 				progressCb := func(current, total int, msg string) {
 					console.UpdateTaskActivity(username)
@@ -35,7 +37,7 @@ var coversCmd = &cobra.Command{
 					}
 				}
 
-				err := appClient.DownloadCoversForUser(username, fileLogger, progressCb)
+				err := appClient.DownloadCoversForUser(ctx, username, fileLogger, progressCb)
 				console.RemoveTask(username)
 
 				if err != nil {

--- a/tools/tikwm/cmd/download.go
+++ b/tools/tikwm/cmd/download.go
@@ -1,44 +1,92 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
+	"github.com/perpetuallyhorni/tikwm/pkg/client"
 	"github.com/perpetuallyhorni/tikwm/pkg/pool"
+	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
+	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
 	"github.com/spf13/cobra"
 )
 
-// downloadCmd represents the 'download' command.
-var downloadCmd = &cobra.Command{
-	Use:     "download [targets...]",                                                 // Usage string for the command.
-	Short:   "Download posts or entire user profiles from TikTok (default command).", // Short description of the command.
-	Aliases: []string{"dl"},                                                          // Aliases for the command.
-	Long: `Downloads posts or entire user profiles from TikTok.
-Targets can be usernames or URLs passed as arguments or listed in a targets file.
-This is the default command if you provide targets without a subcommand.`, // Long description of the command.
-	RunE: runDownload, // Function to execute when the command is run.
+// TargetManager manages the dynamic processing of targets from a file.
+type TargetManager struct {
+	cfg       *cliconfig.Config
+	appClient *client.Client
+	logger    *log.Logger
+	console   *cli.Console
+	force     bool
+
+	mu               sync.Mutex
+	activeTasks      map[string]context.CancelFunc
+	watcher          *fsnotify.Watcher
+	shutdown         chan struct{}
+	wg               sync.WaitGroup
+	results          chan string
+	reconcileTrigger chan struct{}
 }
 
-// runDownload contains the core logic for downloading targets.
+// downloadCmd represents the 'download' command.
+var downloadCmd = &cobra.Command{
+	Use:     "download [targets...]",
+	Short:   "Download posts or entire user profiles from TikTok (default command).",
+	Aliases: []string{"dl"},
+	Long: `Downloads posts or entire user profiles from TikTok.
+Targets can be usernames or URLs passed as arguments or listed in a targets file.
+If using a targets file, the file will be monitored for changes, and workers
+will be dynamically reassigned based on the file's content (hot-reloading).
+This is the default command if you provide targets without a subcommand.`,
+	RunE: runDownload,
+}
+
 func runDownload(cmd *cobra.Command, args []string) error {
 	targets := getTargets(cfg, console, args)
 	isFromFile := len(args) == 0
+
 	if len(targets) == 0 {
 		console.Info("No targets specified. Use 'tikwm --help' for more info.")
 		return nil
 	}
 
 	force, _ := cmd.Flags().GetBool("force")
-	console.Info("Processing %d target(s) with %d worker(s)...", len(targets), cfg.MaxWorkers)
+
+	// If using targets file and it's configured, run with hot-reloading.
+	// Otherwise (e.g. command-line args), run as a one-shot command.
+	if isFromFile && cfg.TargetsFile != "" {
+		return runDynamicDownload(force)
+	}
+	return runStaticDownload(force, targets, isFromFile)
+}
+
+func runStaticDownload(force bool, targets []string, isFromFile bool) error {
+	console.Info("Processing %d target(s) with %d worker(s) in static mode...", len(targets), cfg.MaxWorkers)
 	workerPool := pool.New(cfg.MaxWorkers, len(targets))
 
 	for _, targetStr := range targets {
 		target := targetStr // Capture for closure
 		workerPool.Submit(func() {
+			ctx := context.Background()
 			parsed := parseTarget(target)
-			err := processTarget(parsed, appClient, fileLogger, console, force)
+			err := processTargetWithContext(ctx, parsed, appClient, fileLogger, console, force)
 			if err != nil {
-				fileLogger.Printf("ERROR: Failed to process target '%s': %v", target, err)
+				// Only log fatal errors in static mode
+				if !errors.Is(err, context.Canceled) {
+					fileLogger.Printf("ERROR: Failed to process target '%s': %v", target, err)
+				}
 			} else {
+				// Only manage targets file if the source was a file.
 				if isFromFile && strings.TrimSpace(target) != "" {
 					if err := manageTargetsFile(target, parsed.Type, cfg.TargetsFile, console); err != nil {
 						console.Warn("Could not update targets file for '%s': %v", target, err)
@@ -51,4 +99,230 @@ func runDownload(cmd *cobra.Command, args []string) error {
 	workerPool.Stop()
 	console.StopRenderer()
 	return nil
+}
+
+func runDynamicDownload(force bool) error {
+	manager, err := NewTargetManager(force)
+	if err != nil {
+		return fmt.Errorf("failed to create target manager: %w", err)
+	}
+
+	// Handle shutdown on Ctrl+C
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		console.Info("\nShutdown signal received, stopping workers...")
+		manager.Stop()
+	}()
+
+	return manager.Run()
+}
+
+// NewTargetManager creates a new manager for dynamic target processing.
+func NewTargetManager(force bool) (*TargetManager, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	return &TargetManager{
+		cfg:              cfg,
+		appClient:        appClient,
+		logger:           fileLogger,
+		console:          console,
+		force:            force,
+		activeTasks:      make(map[string]context.CancelFunc),
+		watcher:          watcher,
+		shutdown:         make(chan struct{}),
+		results:          make(chan string),
+		reconcileTrigger: make(chan struct{}, 1),
+	}, nil
+}
+
+// Run starts the main loop of the TargetManager.
+func (tm *TargetManager) Run() error {
+	defer tm.watcher.Close()
+
+	// Watch the parent directory of the targets file for robustness.
+	targetsDir := filepath.Dir(tm.cfg.TargetsFile)
+	if err := os.MkdirAll(targetsDir, 0750); err != nil {
+		return fmt.Errorf("could not create targets directory '%s': %w", targetsDir, err)
+	}
+	if err := tm.watcher.Add(targetsDir); err != nil {
+		return fmt.Errorf("could not watch targets directory '%s': %w", targetsDir, err)
+	}
+
+	tm.logger.Printf("Starting target manager, watching %s for changes to %s", targetsDir, filepath.Base(tm.cfg.TargetsFile))
+	tm.console.Info("Starting dynamic target manager. Watching '%s' for changes.", tm.cfg.TargetsFile)
+	tm.console.Info("Top %d targets in the file will be processed in parallel.", tm.cfg.MaxWorkers)
+	tm.console.Info("The rest will be queued and processed as workers become available.")
+	tm.console.Info("Press Ctrl+C to exit.")
+
+	// Start a goroutine to handle worker completions.
+	tm.wg.Add(1)
+	go tm.completionHandler()
+
+	// Initial reconciliation.
+	tm.triggerReconcile()
+
+	for {
+		select {
+		case <-tm.reconcileTrigger:
+			tm.reconcile()
+
+		case event, ok := <-tm.watcher.Events:
+			if !ok {
+				return nil // Watcher closed
+			}
+			// Check if the event is for our specific targets file.
+			if filepath.Clean(event.Name) == filepath.Clean(tm.cfg.TargetsFile) {
+				// We care about writes, creates, and renames (for atomic saves).
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) || event.Has(fsnotify.Rename) {
+					tm.logger.Printf("Detected change in targets file: %s", event.String())
+					time.Sleep(250 * time.Millisecond) // Debounce
+					tm.triggerReconcile()
+				}
+			}
+
+		case err, ok := <-tm.watcher.Errors:
+			if !ok {
+				return nil
+			}
+			tm.logger.Printf("Watcher error: %v", err)
+			tm.console.Warn("File watcher error: %v", err)
+
+		case <-tm.shutdown:
+			tm.logger.Println("Shutdown signal received by manager event loop.")
+			return nil
+		}
+	}
+}
+
+// Stop gracefully shuts down the TargetManager.
+func (tm *TargetManager) Stop() {
+	tm.mu.Lock()
+	// Signal shutdown to the main loop and completion handler.
+	close(tm.shutdown)
+
+	// Cancel all active tasks.
+	for target, cancel := range tm.activeTasks {
+		tm.logger.Printf("Cancelling task for target: %s", target)
+		cancel()
+	}
+	tm.mu.Unlock()
+
+	// Wait for all worker goroutines (processing and completion handler) to finish.
+	tm.wg.Wait()
+	tm.logger.Println("All manager goroutines finished.")
+	tm.console.StopRenderer()
+}
+
+// triggerReconcile sends a signal to the reconcile channel if it's not already full.
+func (tm *TargetManager) triggerReconcile() {
+	select {
+	case tm.reconcileTrigger <- struct{}{}:
+	default: // A reconcile is already pending.
+	}
+}
+
+// completionHandler listens for finished workers and triggers reconciliation.
+func (tm *TargetManager) completionHandler() {
+	defer tm.wg.Done()
+	for {
+		select {
+		case target := <-tm.results:
+			tm.mu.Lock()
+			// Only trigger reconcile if the task was not externally cancelled
+			if _, exists := tm.activeTasks[target]; exists {
+				delete(tm.activeTasks, target)
+				tm.triggerReconcile()
+			}
+			tm.mu.Unlock()
+		case <-tm.shutdown:
+			return
+		}
+	}
+}
+
+// reconcile compares the state of the targets file with the active tasks.
+func (tm *TargetManager) reconcile() {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	allTargets := getTargetsFromFile(tm.cfg.TargetsFile, tm.console)
+	priorityTargets := make(map[string]struct{})
+	for i := 0; i < len(allTargets) && i < tm.cfg.MaxWorkers; i++ {
+		priorityTargets[allTargets[i]] = struct{}{}
+	}
+
+	// Cancel tasks that are no longer a priority.
+	for target, cancel := range tm.activeTasks {
+		if _, isPriority := priorityTargets[target]; !isPriority {
+			tm.logger.Printf("Target '%s' is no longer a priority target, cancelling.", target)
+			tm.console.Warn("Target '%s' removed or de-prioritized. Stopping task.", target)
+			cancel()
+			delete(tm.activeTasks, target)
+			// Remove the task from the console UI immediately for responsiveness.
+			tm.console.RemoveTask(client.ExtractUsername(target))
+			tm.console.RemoveTask("Post " + client.ExtractUsername(target))
+		}
+	}
+
+	// Start new tasks for priority targets that are not already running, if slots are available.
+	activeCount := len(tm.activeTasks)
+	for _, target := range allTargets {
+		if activeCount >= tm.cfg.MaxWorkers {
+			break // All worker slots are busy.
+		}
+		if _, isPriority := priorityTargets[target]; !isPriority {
+			continue // Not a priority target.
+		}
+		if _, isActive := tm.activeTasks[target]; !isActive {
+			tm.logger.Printf("New priority target '%s', starting task.", target)
+			ctx, cancel := context.WithCancel(context.Background())
+			tm.activeTasks[target] = cancel
+			activeCount++
+			tm.wg.Add(1)
+			go tm.processTarget(ctx, target)
+		}
+	}
+}
+
+// processTarget is the goroutine function for a single worker.
+func (tm *TargetManager) processTarget(ctx context.Context, target string) {
+	defer tm.wg.Done()
+
+	parsed := parseTarget(target)
+	err := processTargetWithContext(ctx, parsed, tm.appClient, tm.logger, tm.console, tm.force)
+
+	// On successful completion (err is nil), manage the targets file.
+	if err == nil {
+		tm.console.Success("Target '%s' finished processing.", target)
+		if strings.TrimSpace(target) != "" {
+			tm.updateTargetsFileOnSuccess(target, parsed.Type)
+		}
+	} else if !errors.Is(err, context.Canceled) {
+		// Log errors, but not cancellations.
+		tm.console.Error("Target '%s' finished with an error.", target)
+		tm.logger.Printf("ERROR processing target %s: %v", target, err)
+	}
+
+	// Signal completion to the manager regardless of outcome.
+	select {
+	case tm.results <- target:
+	case <-tm.shutdown:
+	}
+}
+
+// updateTargetsFileOnSuccess handles the file modification logic safely.
+func (tm *TargetManager) updateTargetsFileOnSuccess(target, targetType string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	// Writing to the file will trigger the watcher. This is expected and desired.
+	if err := manageTargetsFile(target, targetType, tm.cfg.TargetsFile, tm.console); err != nil {
+		tm.console.Warn("Could not update targets file for '%s': %v", target, err)
+		tm.logger.Printf("WARN: Could not update targets file for '%s': %v", target, err)
+	}
 }

--- a/tools/tikwm/cmd/download.go
+++ b/tools/tikwm/cmd/download.go
@@ -143,7 +143,11 @@ func NewTargetManager(force bool) (*TargetManager, error) {
 
 // Run starts the main loop of the TargetManager.
 func (tm *TargetManager) Run() error {
-	defer tm.watcher.Close()
+	defer func() {
+		if err := tm.watcher.Close(); err != nil {
+			tm.logger.Printf("Error closing watcher: %v", err)
+		}
+	}()
 	targetsDir := filepath.Dir(tm.cfg.TargetsFile)
 	if err := os.MkdirAll(targetsDir, 0750); err != nil {
 		return fmt.Errorf("could not create targets directory '%s': %w", targetsDir, err)
@@ -406,7 +410,11 @@ func readLines(filePath string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Printf("Error closing file: %v", err)
+		}
+	}()
 	var lines []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {

--- a/tools/tikwm/cmd/fix.go
+++ b/tools/tikwm/cmd/fix.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/perpetuallyhorni/tikwm/pkg/client"
@@ -28,6 +29,7 @@ and downloads any videos that are missing the qualities specified in your config
 		for _, target := range targets {
 			username := client.ExtractUsername(target) // Capture for closure
 			workerPool.Submit(func() {
+				ctx := context.Background()
 				console.AddTask(username, "Starting fix...", cli.OpFeedFetch)
 				progressCb := func(current, total int, msg string) {
 					console.UpdateTaskActivity(username)
@@ -38,7 +40,7 @@ and downloads any videos that are missing the qualities specified in your config
 					}
 				}
 
-				err := appClient.FixProfile(username, fileLogger, progressCb)
+				err := appClient.FixProfile(ctx, username, fileLogger, progressCb)
 				console.RemoveTask(username)
 
 				if err != nil {

--- a/tools/tikwm/cmd/helpers.go
+++ b/tools/tikwm/cmd/helpers.go
@@ -67,6 +67,9 @@ func applyFlagOverrides(cmd *cobra.Command, cfg *cliconfig.Config) {
 	if cmd.Flag("feed-cache-ttl").Changed {
 		cfg.FeedCacheTTL, _ = cmd.Flags().GetString("feed-cache-ttl")
 	}
+	if cmd.Flag("bind").Changed {
+		cfg.BindAddress, _ = cmd.Flags().GetString("bind")
+	}
 }
 
 // getTargets retrieves targets from command-line arguments or a targets file.

--- a/tools/tikwm/cmd/helpers.go
+++ b/tools/tikwm/cmd/helpers.go
@@ -70,6 +70,12 @@ func applyFlagOverrides(cmd *cobra.Command, cfg *cliconfig.Config) {
 	if cmd.Flag("bind").Changed {
 		cfg.BindAddress, _ = cmd.Flags().GetString("bind")
 	}
+	if cmd.Flag("daemon").Changed {
+		cfg.DaemonMode, _ = cmd.Flags().GetBool("daemon")
+	}
+	if cmd.Flag("daemon-poll-interval").Changed {
+		cfg.DaemonPollInterval, _ = cmd.Flags().GetString("daemon-poll-interval")
+	}
 }
 
 // getTargets retrieves targets from command-line arguments or a targets file.

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/perpetuallyhorni/tikwm/pkg/storage/sqlite"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
 	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
+	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/network"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/update"
 	"github.com/spf13/cobra"
 )
@@ -79,6 +80,14 @@ For example:
 
 		// The full setup for commands that need it.
 		if !isLightweightCmd {
+			// Set up global HTTP transport if bind address is specified.
+			if cfg.BindAddress != "" {
+				transport, err := network.NewHTTPTransport(cfg.BindAddress)
+				if err != nil {
+					return err
+				}
+				network.SetGlobalTransport(transport)
+			}
 			targets := getTargets(cfg, console, args)
 			// Check the flag to clean logs or not.
 			cleanLogs, _ := cmd.Flags().GetBool("clean-logs")
@@ -151,7 +160,6 @@ For example:
 	SilenceErrors: true,
 }
 
-// ... rest of root.go is unchanged
 // init initializes the command line interface.
 func init() {
 	// Initialize the console.
@@ -202,6 +210,9 @@ func init() {
 	rootCmd.PersistentFlags().String("cover-type", "", `Cover type to download ("cover", "origin", "dynamic"). Overrides config.`)
 	rootCmd.PersistentFlags().Bool("download-avatars", false, "Enable downloading of user avatars. Overrides config.")
 	rootCmd.PersistentFlags().Bool("save-post-title", false, "Save post title to a .txt file. Overrides config.")
+
+	// Network flags
+	rootCmd.PersistentFlags().String("bind", "", "Outbound IP address or interface to bind to (overrides config)")
 
 	// Caching flags
 	rootCmd.PersistentFlags().Bool("feed-cache", false, "Enable or disable caching of user feeds. Overrides config.")

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -9,10 +9,10 @@ import (
 
 	tikwm "github.com/perpetuallyhorni/tikwm/internal"
 	"github.com/perpetuallyhorni/tikwm/pkg/client"
+	"github.com/perpetuallyhorni/tikwm/pkg/network"
 	"github.com/perpetuallyhorni/tikwm/pkg/storage/sqlite"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/cli"
 	cliconfig "github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/config"
-	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/network"
 	"github.com/perpetuallyhorni/tikwm/tools/tikwm/internal/update"
 	"github.com/spf13/cobra"
 )
@@ -45,7 +45,6 @@ func SetVersion(v string) {
 	}
 }
 
-// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "tikwm [command|targets...]",
 	Short: "A downloader for TikTok, powered by tikwm.com.",
@@ -80,14 +79,11 @@ For example:
 
 		// The full setup for commands that need it.
 		if !isLightweightCmd {
-			// Set up global HTTP transport if bind address is specified.
-			if cfg.BindAddress != "" {
-				transport, err := network.NewHTTPTransport(cfg.BindAddress)
-				if err != nil {
-					return err
-				}
-				network.SetGlobalTransport(transport)
+			// Initialize the network manager with IP rotation.
+			if err := network.InitManager(cfg.BindAddress); err != nil {
+				return err
 			}
+
 			targets := getTargets(cfg, console, args)
 			// Check the flag to clean logs or not.
 			cleanLogs, _ := cmd.Flags().GetBool("clean-logs")

--- a/tools/tikwm/cmd/root.go
+++ b/tools/tikwm/cmd/root.go
@@ -214,6 +214,10 @@ func init() {
 	rootCmd.PersistentFlags().Bool("feed-cache", false, "Enable or disable caching of user feeds. Overrides config.")
 	rootCmd.PersistentFlags().String("feed-cache-ttl", "", `Time-to-live for feed cache, e.g., "1h", "30m". Overrides config.`)
 
+	// Daemon flags
+	rootCmd.PersistentFlags().Bool("daemon", false, "Enable daemon mode for continuous, low-frequency polling. Overrides config.")
+	rootCmd.PersistentFlags().String("daemon-poll-interval", "", `Polling interval for daemon mode, e.g., "60s". Overrides config.`)
+
 	// Add subcommands.
 	rootCmd.AddCommand(downloadCmd)
 	rootCmd.AddCommand(infoCmd)

--- a/tools/tikwm/internal/config/config.go
+++ b/tools/tikwm/internal/config/config.go
@@ -1,3 +1,4 @@
+// tools/tikwm/internal/config/config.go
 package cliconfig
 
 import (
@@ -132,6 +133,11 @@ retry_on_429: %t
 # Path to the ffmpeg executable. Used to validate downloaded videos.
 ffmpeg_path: "%s"
 
+# Network
+# Specify the local IP address or network interface name for outbound connections.
+# Leave blank to let the OS decide. Examples: "192.168.1.100", "eth0"
+bind_address: "%s"
+
 # Caching
 # Enable caching of user feeds to speed up repeated runs.
 feed_cache: %t
@@ -145,7 +151,7 @@ editor: "%s"
 check_for_updates: %t
 # Automatically install new versions of tikwm. If false, you will be notified to run 'tikwm update'.
 auto_update: %t
-`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.FeedCache, cfg.FeedCacheTTL, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
+`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.BindAddress, cfg.FeedCache, cfg.FeedCacheTTL, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
 	content = strings.ReplaceAll(content, "\\", "/")
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write default config file: %w", err)

--- a/tools/tikwm/internal/config/config.go
+++ b/tools/tikwm/internal/config/config.go
@@ -1,4 +1,3 @@
-// tools/tikwm/internal/config/config.go
 package cliconfig
 
 import (
@@ -20,13 +19,15 @@ const AppName = "tikwm"
 
 // Config extends the core config with CLI-specific options.
 type Config struct {
-	config.Config   `koanf:",squash"`
-	TargetsFile     string `koanf:"targets_file"`
-	DatabasePath    string `koanf:"database_path"`
-	Editor          string `koanf:"editor"`
-	CheckForUpdates bool   `koanf:"check_for_updates"` // Check for new versions on startup.
-	AutoUpdate      bool   `koanf:"auto_update"`       // Automatically install new versions.
-	MaxWorkers      int    `koanf:"max_workers"`       // Maximum number of concurrent workers.
+	config.Config      `koanf:",squash"`
+	TargetsFile        string `koanf:"targets_file"`
+	DatabasePath       string `koanf:"database_path"`
+	Editor             string `koanf:"editor"`
+	CheckForUpdates    bool   `koanf:"check_for_updates"` // Check for new versions on startup.
+	AutoUpdate         bool   `koanf:"auto_update"`       // Automatically install new versions.
+	MaxWorkers         int    `koanf:"max_workers"`       // Maximum number of concurrent workers.
+	DaemonMode         bool   `koanf:"daemon_mode"`
+	DaemonPollInterval string `koanf:"daemon_poll_interval"`
 }
 
 // Default returns the default CLI configuration.
@@ -42,13 +43,15 @@ func Default() (*Config, error) {
 	}
 
 	return &Config{
-		Config:          *coreCfg,
-		DatabasePath:    dbPath,
-		TargetsFile:     targetsPath,
-		Editor:          "", // Default editor is determined in the 'edit' command logic
-		CheckForUpdates: true,
-		AutoUpdate:      false,
-		MaxWorkers:      runtime.NumCPU(),
+		Config:             *coreCfg,
+		DatabasePath:       dbPath,
+		TargetsFile:        targetsPath,
+		Editor:             "", // Default editor is determined in the 'edit' command logic
+		CheckForUpdates:    true,
+		AutoUpdate:         false,
+		MaxWorkers:         runtime.NumCPU(),
+		DaemonMode:         false,
+		DaemonPollInterval: "60s",
 	}, nil
 }
 
@@ -144,6 +147,12 @@ feed_cache: %t
 # How long to keep feed cache before it's considered stale (e.g., "1h", "30m", "2h15m").
 feed_cache_ttl: "%s"
 
+# Daemon Mode (for use with targets file)
+# When enabled, the app will run continuously and poll for new content at a reduced rate after a full pass.
+daemon_mode: %t
+# The interval to wait between checks when in low-frequency daemon poll state.
+daemon_poll_interval: "%s"
+
 # Other
 # Editor to use for the 'edit' command. If empty, it will check $EDITOR, then common editors.
 editor: "%s"
@@ -151,7 +160,7 @@ editor: "%s"
 check_for_updates: %t
 # Automatically install new versions of tikwm. If false, you will be notified to run 'tikwm update'.
 auto_update: %t
-`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.BindAddress, cfg.FeedCache, cfg.FeedCacheTTL, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
+`, cfg.DownloadPath, cfg.TargetsFile, cfg.DatabasePath, cfg.MaxWorkers, cfg.Quality, cfg.Since, cfg.DownloadCovers, cfg.CoverType, cfg.DownloadAvatars, cfg.SavePostTitle, cfg.RetryOn429, cfg.FfmpegPath, cfg.BindAddress, cfg.FeedCache, cfg.FeedCacheTTL, cfg.DaemonMode, cfg.DaemonPollInterval, cfg.Editor, cfg.CheckForUpdates, cfg.AutoUpdate)
 	content = strings.ReplaceAll(content, "\\", "/")
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write default config file: %w", err)

--- a/tools/tikwm/internal/network/network.go
+++ b/tools/tikwm/internal/network/network.go
@@ -1,0 +1,108 @@
+package network
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var globalTransport http.RoundTripper
+
+// SetGlobalTransport sets the transport to be used for all HTTP clients.
+func SetGlobalTransport(transport http.RoundTripper) {
+	globalTransport = transport
+	http.DefaultClient = &http.Client{Transport: transport}
+}
+
+// GetGlobalTransport returns the currently configured global HTTP transport.
+// If none is set, it returns http.DefaultTransport.
+func GetGlobalTransport() http.RoundTripper {
+	if globalTransport != nil {
+		return globalTransport
+	}
+	return http.DefaultTransport
+}
+
+// resolveBindAddr takes a string that can be an IP address or an interface name
+// and returns a resolvable *net.TCPAddr.
+func resolveBindAddr(addrOrInterface string) (*net.TCPAddr, error) {
+	// First, try to parse as an IP address directly.
+	ip := net.ParseIP(addrOrInterface)
+	if ip != nil {
+		return &net.TCPAddr{IP: ip}, nil
+	}
+
+	// If it's not a valid IP, assume it's an interface name.
+	iface, err := net.InterfaceByName(addrOrInterface)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find network interface '%s': %w", addrOrInterface, err)
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get addresses for interface '%s': %w", addrOrInterface, err)
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("network interface '%s' has no addresses", addrOrInterface)
+	}
+
+	// Find the first usable IPv4 address on the interface.
+	for _, addr := range addrs {
+		var ip net.IP
+		// The addr is of type net.Addr, which can be *net.IPNet or *net.IPAddr.
+		// We need to check and extract the IP.
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			ip = ipNet.IP
+		} else if ipAddr, ok := addr.(*net.IPAddr); ok {
+			ip = ipAddr.IP
+		}
+
+		if ip != nil && ip.To4() != nil && !ip.IsLoopback() {
+			return &net.TCPAddr{IP: ip}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no usable IPv4 address found for interface '%s'", addrOrInterface)
+}
+
+// NewHTTPTransport creates a new http.Transport that binds to the specified local address.
+func NewHTTPTransport(bindAddr string) (*http.Transport, error) {
+	if strings.TrimSpace(bindAddr) == "" {
+		return nil, fmt.Errorf("bind address cannot be empty")
+	}
+
+	localAddr, err := resolveBindAddr(bindAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve bind address '%s': %w", bindAddr, err)
+	}
+
+	// Create a custom dialer with the local address set.
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		LocalAddr: localAddr,
+	}
+
+	// Create a transport that uses our custom dialer.
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// Verify that the transport can establish a connection.
+	testClient := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+	resp, err := testClient.Get("https://api.github.com") // A reliable, neutral endpoint.
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify connection with bind address %s: %w", localAddr.IP, err)
+	}
+	_ = resp.Body.Close()
+
+	return transport, nil
+}

--- a/tools/tikwm/internal/update/update.go
+++ b/tools/tikwm/internal/update/update.go
@@ -1,4 +1,3 @@
-// tools/tikwm/internal/update/update.go
 package update
 
 import (
@@ -271,7 +270,7 @@ func ApplyUpdate(console *cli.Console, currentVersion string) error {
 	}
 
 	console.Info("Downloading: %s", assetName)
-	resp, err := http.Get(assetURL) // #nosec G107
+	resp, err := http.DefaultClient.Get(assetURL) // #nosec G107
 	if err != nil {
 		return fmt.Errorf("failed to download asset: %w", err)
 	}


### PR DESCRIPTION
Introduce a dynamic processing mode for the download command when using a targets file. The application now monitors the targets file for modifications, enabling live updates to the processing queue without requiring a restart.

This new mode is orchestrated by a TargetManager which: Uses fsnotify to watch the targets file's directory for changes, Manages a pool of workers, assigning them to the highest-priority targets (top n lines in the file, where n is max_workers). Dynamically re-allocates workers by cancelling tasks for targets that are removed or de-prioritized and assigning newly available workers to new or higher-priority targets.

Closes #49 

Introduce a global --bind flag and a corresponding bind_address configuration key to allow users to specify a local IP address or a network interface name for all outbound network connections made. Add BindAddress to core and CLI configuration structs. Implement a new network package to create a custom http.Transport with a dialer bound to the specified local address. Set the custom transport on the global http.DefaultClient to ensure all API calls, downloads via the grab library, and self-update checks use the specified outbound address. Add error handling to validate the specified address or interface at startup.

Closes #51

Introduce a mechanism to handle multiple outbound IP addresses or network interfaces, as specified by a comma-separated list in the --bind flag or bind_address config key. Add a new pkg/network package containing an IPRotator to manage the pool of addresses, their states (active, exhausted), and the round-robin logic. The API client now detects the specific "daily limit reached" error message from the API. Upon detection, the currently used IP is marked as exhausted for 24 hours, and the failed request is automatically retried using the next available IP from the pool. If all IPs become exhausted, requests will fail until an IP's exhaustion timer expires. The application now initializes a global network manager that sets a dynamic transport on http.DefaultClient, ensuring consistent behavior across all network operations.

Closes #53

Introduce a new daemon mode for continuous, low-API-usage monitoring of targets specified in a file. Add --daemon flag and daemon_mode config key to enable the feature. Add --daemon-poll-interval flag and daemon_poll_interval config key to control the polling frequency. The download command now runs in a dynamic, stateful mode when daemon mode is enabled. The TargetManager now manages a special marker comment (# Completed targets...) in the targets.txt file to track state. On startup, the manager resets the file, moving all targets above the marker. As targets are successfully processed, they are moved below the marker. When no targets remain above the marker, the manager enters a low-frequency polling state, sleeping for daemon_poll_interval before resetting the targets file and starting a new cycle. Any manual change to the targets file will immediately interrupt the poll and trigger a reconciliation, ensuring instant response to new targets. Reduce API consumption for users running the application as a 24/7 service.

Closes #52
